### PR TITLE
Remove duplication in the request layer and bound five unbounded failure modes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# OBEY Clean Code by Robert C. Martin
+
+## When to use
+
+Use when readability, local reasoning, and maintainable code shape are the main concerns, especially during everyday implementation and review.
+
+## Primary bias to correct
+
+Working code is not automatically clean code.
+
+## Decision rules
+
+- Treat cleanliness as part of delivery. Preserve behavior, leave touched code cleaner within scope, and do not add mess because the schedule is tight or a rewrite is promised.
+- Write for local reasoning. A reader should understand the path without reconstructing hidden state, wide jumps, or naming trivia.
+- Use precise names and one term per concept. Rename code when vocabulary hides intent, overloads meaning, or forces comments to compensate.
+- Keep functions small, focused, and at one level of abstraction. Tell the story top-down so intent appears before detail.
+- Keep parameters few and meaningful. Avoid boolean flags, output parameters, and grab-bag argument lists; model the concept instead.
+- Separate commands from queries and eliminate hidden side effects. A function that answers should not also mutate behind the reader's back.
+- Keep the happy path readable. Isolate error handling, invalid-state handling, and cleanup; prefer explicit optionality or typed results over null-like sentinel flow when the language supports it.
+- Expose behavior rather than raw representation. Avoid train-wreck access, utility dumping grounds, and classes or modules with mixed responsibilities.
+- Keep construction, framework, persistence, transaction, security, and vendor details outside business behavior.
+- Make public APIs small, explicit, and hard to misuse. Encode boundary logic, required order, and likely changes where readers can see them.
+- Use comments only for rationale, constraints, warnings, or external contracts. Do not narrate code instead of improving it.
+- Treat tests as production code: readable, deterministic, aligned with the behavior or contract they protect, and backed by proportionate validation before calling the change done.
+- Let design emerge through tests, duplication removal, expressiveness, and minimal structure; do not add needless abstractions or infrastructure.
+- When touching code, remove the smell that most increases change cost, but do not silently broaden the task beyond the smallest cleanup that makes the requested change safe.
+
+## Trigger rules
+
+- When a function mixes setup, validation, computation, and side effects, split the phases.
+- When a comment explains control flow, simplify names or structure before keeping the comment.
+- When a function both mutates and answers, or hides a mode switch behind a flag, separate the responsibilities.
+- When duplication, repeated switches, or primitive clusters appear, name the concept with an argument object, polymorphism, special case, or other small abstraction.
+- When a boundary leaks framework, vendor, or persistence quirks inward, add or strengthen a local adapter.
+- When async or concurrency enters, isolate threading policy, minimize shared mutable state, define shutdown, and test timing-sensitive behavior.
+- When fixing a bug or changing behavior, add or update the test that protects the intended contract.
+- When cleanup starts spreading into unrelated areas, cut back to the smallest refactor that keeps the requested change safe and readable.
+
+## Final checklist
+
+- Can a reader follow the change locally?
+- Are names and APIs carrying the meaning without narration?
+- Is mutation explicit and the happy path still clear?
+- Did framework, persistence, vendor, and construction details stay behind boundaries?
+- Did I remove at least one smell from the touched area?
+- Do tests protect the changed behavior or contract?
+- Did I actually run the relevant tests or checks for this change?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,30 @@ with `NoSuchMethodError` at runtime. Recompiling is enough; no source edit is
 needed. Nothing was removed: `Auth`'s per-case `toString` moved onto the `Auth`
 parent class, which callers still reach through normal virtual dispatch.
 
+The API snapshot gained entries in `backend-zio` and `backend-okhttp` only;
+`core` and `client` are byte-identical. Every entry is an addition — the
+existing `ZioGiteaDownloads(config, backend)` constructor is unchanged, so code
+compiled against it keeps working.
+
 ### Security
+
+- **Control characters in credentials are rejected at parse time.** `fromEnv`
+  and the HOCON readers trimmed surrounding whitespace but accepted a CR or LF
+  *inside* `token`, `username`, `password`, `user-agent` or `otp`. Such a value
+  parsed cleanly and then failed on the first request — as an untyped
+  `IllegalArgumentException` from the JDK that quoted the credential back, after
+  the request had already been retried — and on a backend that does not
+  validate header values it is header injection. These five settings now fail
+  with a typed `GiteaConfigError` naming the setting (never the value).
+  `GiteaConfig.withToken` and `Auth.Token(...)` build a config directly and are
+  not covered.
+
+- **`GiteaError.message` is bounded like the body it comes from.**
+  `GiteaResponseMapper` capped the response body it kept on an error at 8 KiB so
+  a failed request could not put a multi-megabyte payload into a log line, but
+  lifted `message` out of that same untrusted body with no cap at all. A
+  response of `{"message": "<4 MB>"}` defeated the ceiling entirely. Both fields
+  are now capped.
 
 - **Credentials no longer appear in `toString`.** `Auth`, `GiteaConfig` and
   `GiteaDownloadRequest` used the `toString` the compiler generates for a case
@@ -75,6 +98,30 @@ parent class, which callers still reach through normal virtual dispatch.
   follow redirects; configs without one are unaffected.
 
 ### Fixed
+
+- **A stalled request is no longer retried into a much longer stall.** The
+  five-minute end-to-end cap is applied per attempt, and an exhausted cap was
+  classified as a retryable transport failure — so against the default
+  `maxRetries = 3` a server that answered `200 OK` and then stopped sending held
+  the caller for twenty minutes rather than five, across four attempts that
+  could not have succeeded. An exhausted budget is now surfaced immediately.
+  sttp's own timeouts stay retryable.
+
+- **Streaming downloads had no stall backstop at all.** `GiteaDownloads` sends
+  straight at the backend, bypassing the executor, with `readTimeout` as its
+  only limit — and that value reaches the JDK as `HttpRequest.timeout`, which
+  stops applying the moment response headers arrive. The path meant for the
+  *largest* bodies was therefore the one that could hang forever. The stream now
+  fails if five minutes pass with no data. The budget measures the gap between
+  chunks, so a genuinely large archive is never cut off.
+
+- **The OkHttp backend had no call timeout.** `ownedClient` set `connectTimeout`
+  and `readTimeout` but left `callTimeout` at OkHttp's default of `0`, meaning
+  no limit. `readTimeout` bounds one socket read, so a server emitting a byte
+  every 29 seconds kept a call alive indefinitely — and because this backend
+  cannot cancel an orphaned call, and OkHttp's dispatcher runs five requests per
+  host and queues the rest unbounded, a handful of stuck calls stalled every
+  request behind them. A borrowed client keeps a call timeout it already set.
 
 - **Pagination silently dropped data when the server clamped the page size.**
   `hasNext` compared the page number against the page size that was *requested*

--- a/README.md
+++ b/README.md
@@ -163,6 +163,15 @@ Config errors name the invalid setting without echoing credential values, and
 `toString` on a `GiteaConfig` or an `Auth` redacts the token, password and
 one-time password. Read the fields directly when you need the real value.
 
+Values that become HTTP header content — `token`, `username`, `password`,
+`user-agent` and `otp` — are rejected at parse time if they contain a control
+character. Surrounding whitespace is still trimmed, as before; what is new is
+that a CR or LF *inside* the value is an error. Previously such a value parsed
+cleanly and then failed on the first request, as an untyped
+`IllegalArgumentException` from the JDK that quoted the credential back. This
+applies to `fromEnv` and the HOCON readers; `GiteaConfig.withToken` and
+`Auth.Token(...)` construct a config directly and are not validated.
+
 Credentials embedded in the URL (`https://user:pass@gitea.example`) are stripped
 rather than rejected: nothing ever transmitted them, and keeping them only
 risked leaking the password through an exception message. Note also that a
@@ -337,6 +346,14 @@ applying once response *headers* arrive, so a server that answers immediately
 and then sends the body one byte at a time would otherwise hang the call
 indefinitely.
 
+An exhausted attempt budget is surfaced, not retried. A stalled connection is
+the most expensive failure the client has and the one least likely to have
+cleared a moment later, so spending the budget `maxRetries + 1` times bought
+nothing — it only turned a five-minute stall into a twenty-minute one. Note
+that this budget bounds one *attempt*: it is not a deadline for the whole call,
+which also includes backoff sleeps. If you need a single deadline covering
+everything, wrap the call in ZIO's own `.timeout`.
+
 > **Upgrading from 1.0.0:** `maxRetries` used to default to `0`. If your tests
 > stub a `5xx` or `429` and run under zio-test's `TestClock`, they will now
 > block on a clock the test never advances. Set `maxRetries = 0` on the config
@@ -372,6 +389,11 @@ ZIO.serviceWithZIO[GiteaDownloads] { downloads =>
 This requires a `ZioStreams` backend, so it is `backend-zio` only (the OkHttp
 bridge keeps the buffered methods). Streaming downloads are not retried, since a
 partially consumed body cannot be safely replayed.
+
+A download that stops producing fails rather than hanging: the stream fails if
+five minutes pass with no data at all. The budget measures the *gap between
+chunks*, not total download time, so a genuinely large archive is never cut off
+as long as it keeps arriving.
 
 ## Examples
 

--- a/api-snapshot/backend-okhttp.txt
+++ b/api-snapshot/backend-okhttp.txt
@@ -12,6 +12,7 @@ public final class io.worxbend.gitea4s.backend.okhttp.OkHttpGiteaBackend {
   public static zio.ZLayer<java.lang.Object, scala.runtime.Nothing$, io.worxbend.gitea4s.GiteaClient> usingClient(io.worxbend.gitea4s.GiteaConfig, okhttp3.OkHttpClient);
   public static zio.ZLayer<io.worxbend.gitea4s.GiteaConfig, scala.runtime.Nothing$, io.worxbend.gitea4s.GiteaClient> usingClient(okhttp3.OkHttpClient);
   public static zio.ZLayer<java.lang.Object, java.lang.Throwable, io.worxbend.gitea4s.GiteaClient> withBasic(sttp.model.Uri, java.lang.String, java.lang.String);
+  public static okhttp3.OkHttpClient withRequestReadTimeout(okhttp3.OkHttpClient, io.worxbend.gitea4s.GiteaConfig);
   public static zio.ZLayer<java.lang.Object, java.lang.Throwable, io.worxbend.gitea4s.GiteaClient> withToken(sttp.model.Uri, java.lang.String);
 }
 
@@ -27,6 +28,7 @@ public final class io.worxbend.gitea4s.backend.okhttp.OkHttpGiteaBackend$ implem
   public zio.ZLayer<io.worxbend.gitea4s.GiteaConfig, scala.runtime.Nothing$, io.worxbend.gitea4s.GiteaClient> usingClient(okhttp3.OkHttpClient);
   public zio.ZLayer<java.lang.Object, scala.runtime.Nothing$, io.worxbend.gitea4s.GiteaClient> usingClient(io.worxbend.gitea4s.GiteaConfig, okhttp3.OkHttpClient);
   public okhttp3.OkHttpClient ownedClient(io.worxbend.gitea4s.GiteaConfig);
+  public okhttp3.OkHttpClient withRequestReadTimeout(okhttp3.OkHttpClient, io.worxbend.gitea4s.GiteaConfig);
   public zio.ZIO<zio.Scope, java.lang.Throwable, okhttp3.OkHttpClient> scopedOwnedClient(io.worxbend.gitea4s.GiteaConfig);
 }
 

--- a/api-snapshot/backend-zio.txt
+++ b/api-snapshot/backend-zio.txt
@@ -47,6 +47,7 @@ public final class io.worxbend.gitea4s.backend.zio.ZioGiteaBackend$ implements j
 
 ## io.worxbend.gitea4s.backend.zio.ZioGiteaDownloads
 public final class io.worxbend.gitea4s.backend.zio.ZioGiteaDownloads implements io.worxbend.gitea4s.backend.zio.GiteaDownloads {
+  public io.worxbend.gitea4s.backend.zio.ZioGiteaDownloads(io.worxbend.gitea4s.GiteaConfig, sttp.client4.StreamBackend<zio.ZIO<java.lang.Object, java.lang.Throwable, java.lang.Object>, sttp.capabilities.zio.ZioStreams>, java.time.Duration);
   public io.worxbend.gitea4s.backend.zio.ZioGiteaDownloads(io.worxbend.gitea4s.GiteaConfig, sttp.client4.StreamBackend<zio.ZIO<java.lang.Object, java.lang.Throwable, java.lang.Object>, sttp.capabilities.zio.ZioStreams>);
   public zio.stream.ZStream<java.lang.Object, io.worxbend.gitea4s.error.GiteaError, java.lang.Object> rawFile(java.lang.String, java.lang.String, java.lang.String, io.worxbend.gitea4s.http.ContentsParams);
   public io.worxbend.gitea4s.http.ContentsParams rawFile$default$4();
@@ -54,4 +55,14 @@ public final class io.worxbend.gitea4s.backend.zio.ZioGiteaDownloads implements 
   public io.worxbend.gitea4s.http.ContentsParams mediaFile$default$4();
   public zio.stream.ZStream<java.lang.Object, io.worxbend.gitea4s.error.GiteaError, java.lang.Object> archive(java.lang.String, java.lang.String, java.lang.String, io.worxbend.gitea4s.http.ArchiveParams);
   public io.worxbend.gitea4s.http.ArchiveParams archive$default$4();
+  public static io.worxbend.gitea4s.backend.zio.ZioGiteaDownloads withStallTimeout(io.worxbend.gitea4s.GiteaConfig, sttp.client4.StreamBackend<zio.ZIO<java.lang.Object, java.lang.Throwable, java.lang.Object>, sttp.capabilities.zio.ZioStreams>, java.time.Duration);
+}
+
+## io.worxbend.gitea4s.backend.zio.ZioGiteaDownloads$
+public final class io.worxbend.gitea4s.backend.zio.ZioGiteaDownloads$ implements java.io.Serializable {
+  public static final io.worxbend.gitea4s.backend.zio.ZioGiteaDownloads$ MODULE$;
+  public static {};
+  public java.time.Duration stallTimeout();
+  public io.worxbend.gitea4s.backend.zio.ZioGiteaDownloads withStallTimeout(io.worxbend.gitea4s.GiteaConfig, sttp.client4.StreamBackend<zio.ZIO<java.lang.Object, java.lang.Throwable, java.lang.Object>, sttp.capabilities.zio.ZioStreams>, java.time.Duration);
+  public io.worxbend.gitea4s.error.GiteaError io$worxbend$gitea4s$backend$zio$ZioGiteaDownloads$$$stalled(java.time.Duration);
 }

--- a/backend-okhttp/src/io/worxbend/gitea4s/backend/okhttp/OkHttpGiteaBackend.scala
+++ b/backend-okhttp/src/io/worxbend/gitea4s/backend/okhttp/OkHttpGiteaBackend.scala
@@ -1,5 +1,6 @@
 package io.worxbend.gitea4s.backend.okhttp
 
+import io.worxbend.gitea4s.internal.GiteaRequestExecutor
 import io.worxbend.gitea4s.model.Auth
 import io.worxbend.gitea4s.{GiteaClient, GiteaConfig}
 import okhttp3.{Authenticator, Credentials, OkHttpClient, Request as OkHttpRequest, Response as OkHttpResponse, Route}
@@ -34,10 +35,15 @@ import scala.concurrent.{ExecutionContext, Future}
   * `Promise#future` is not.
   *
   * The consequence is bounded rather than a leak. The orphaned call is capped by
-  * `GiteaConfig.timeout` — that value is the OkHttp read timeout — and when it
-  * does finish, sttp reads the body and closes the response on OkHttp's
-  * dispatcher thread, which returns the connection to the pool. What is lost is
-  * releasing the connection *early*, not releasing it at all.
+  * OkHttp's call timeout, and when it does finish, sttp reads the body and closes
+  * the response on OkHttp's dispatcher thread, which returns the connection to
+  * the pool. What is lost is releasing the connection *early*, not releasing it
+  * at all.
+  *
+  * `GiteaConfig.timeout` is not what bounds it. That value is the OkHttp *read*
+  * timeout, which limits a single socket read rather than the call, so a server
+  * dribbling one byte at a time never trips it. The cap is the separate call
+  * timeout this module sets — see `callTimeoutMillis`.
   *
   * Where cancellation latency matters — a request racing a deadline shorter than
   * `GiteaConfig.timeout`, or a fiber that is interrupted often — prefer the
@@ -133,6 +139,7 @@ object OkHttpGiteaBackend:
       .followSslRedirects(false)
       .connectTimeout(options.connectionTimeout.toMillis, TimeUnit.MILLISECONDS)
       .readTimeout(config.timeout.toMillis, TimeUnit.MILLISECONDS)
+      .callTimeout(callTimeoutMillis, TimeUnit.MILLISECONDS)
 
     val withProxy = options.proxy.fold(builder) { proxy =>
       val routed = builder.proxySelector(proxy.asJavaProxySelector)
@@ -159,10 +166,39 @@ object OkHttpGiteaBackend:
     * client is the caller's client in every respect that matters — including
     * that shutting theirs down shuts this one down too, and that gitea4s never
     * shuts down either.
+    *
+    * Package-private rather than private so the spec can assert on the derived
+    * client's settings, the same reason [[ownedClient]] is; it is not part of
+    * the published Scala API.
     */
-  private def withRequestReadTimeout(client: OkHttpClient, config: GiteaConfig): OkHttpClient =
-    if client.readTimeoutMillis().toLong == config.timeout.toMillis then client
-    else client.newBuilder().readTimeout(config.timeout.toMillis, TimeUnit.MILLISECONDS).build()
+  private[okhttp] def withRequestReadTimeout(client: OkHttpClient, config: GiteaConfig): OkHttpClient =
+    val readTimeoutMatches = client.readTimeoutMillis().toLong == config.timeout.toMillis
+    // Only when the caller left it at OkHttp's default of 0, which means "no
+    // limit". A caller who chose their own call timeout keeps it.
+    val needsCallTimeout = client.callTimeoutMillis() == 0
+
+    if readTimeoutMatches && !needsCallTimeout then client
+    else
+      val builder = client.newBuilder().readTimeout(config.timeout.toMillis, TimeUnit.MILLISECONDS)
+      (if needsCallTimeout then builder.callTimeout(callTimeoutMillis, TimeUnit.MILLISECONDS) else builder).build()
+
+  /** A ceiling on one whole OkHttp call, which OkHttp does not set by default.
+    *
+    * `readTimeout` bounds one socket read, not the call, so a server that
+    * emits a byte every 29 seconds against the default 30-second timeout keeps
+    * a call alive indefinitely. That matters more here than it would
+    * elsewhere: this backend cannot cancel an orphaned call (see the note on
+    * the object above), and OkHttp's dispatcher runs five requests per host
+    * and queues the rest without bound, so a handful of stuck calls stalls
+    * every request behind them.
+    *
+    * Set from the executor's attempt budget rather than `GiteaConfig.timeout`:
+    * by the time that budget is spent the caller's fiber has already given up,
+    * so ending the call costs nothing — whereas `config.timeout` would kill a
+    * legitimately slow archive fetch that is still making progress.
+    */
+  private val callTimeoutMillis: Long =
+    GiteaRequestExecutor.defaultAttemptTimeout.toMillis
 
   /** Acquires the layer's own client and shuts it down when the scope closes.
     *

--- a/backend-okhttp/test/src/io/worxbend/gitea4s/backend/okhttp/OkHttpGiteaBackendSpec.scala
+++ b/backend-okhttp/test/src/io/worxbend/gitea4s/backend/okhttp/OkHttpGiteaBackendSpec.scala
@@ -11,6 +11,7 @@ import zio.test.*
 
 import java.net.InetSocketAddress
 import java.nio.charset.StandardCharsets
+import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.*
 
 object OkHttpGiteaBackendSpec extends ZIOSpecDefault:
@@ -53,6 +54,45 @@ object OkHttpGiteaBackendSpec extends ZIOSpecDefault:
           // must leave redirects alone, exactly as sttp's own default client does.
           !client.followRedirects(),
           !client.followSslRedirects()
+        )
+      },
+      test("caps a whole call on the client it owns") {
+        // OkHttp's call timeout defaults to 0, which means no limit at all.
+        // `readTimeout` bounds one socket read, so a server emitting a byte
+        // just inside that window keeps a call alive forever — and this
+        // backend cannot cancel an orphaned call, while OkHttp's dispatcher
+        // queues everything behind the five it runs per host.
+        val client = OkHttpGiteaBackend.ownedClient(config)
+
+        assertTrue(client.callTimeoutMillis() > 0)
+      },
+      test("caps a whole call on a borrowed client that had no limit") {
+        // Already carries the read timeout gitea4s wants, so the call timeout
+        // is the only reason left to derive a client at all.
+        val borrowed = OkHttpClient.Builder().readTimeout(config.timeout.toMillis, TimeUnit.MILLISECONDS).build()
+
+        val derived = OkHttpGiteaBackend.withRequestReadTimeout(borrowed, config)
+
+        assertTrue(
+          derived.callTimeoutMillis() > 0,
+          // The caller's own client is never mutated.
+          borrowed.callTimeoutMillis() == 0
+        )
+      },
+      test("leaves a borrowed client's own call timeout alone") {
+        // Ownership does not change, so a caller who chose a call timeout
+        // keeps it — gitea4s only fills in the unset default.
+        val chosen = 42.seconds
+        val borrowed = OkHttpClient
+          .Builder()
+          .callTimeout(chosen.toMillis, TimeUnit.MILLISECONDS)
+          .build()
+
+        val derived = OkHttpGiteaBackend.withRequestReadTimeout(borrowed, config)
+
+        assertTrue(
+          derived.callTimeoutMillis().toLong == chosen.toMillis,
+          derived.readTimeoutMillis().toLong == config.timeout.toMillis
         )
       },
       test("evicts the connection pool of the client it owns when the scope closes") {

--- a/backend-zio/src/io/worxbend/gitea4s/backend/zio/GiteaDownloads.scala
+++ b/backend-zio/src/io/worxbend/gitea4s/backend/zio/GiteaDownloads.scala
@@ -5,8 +5,10 @@ import io.worxbend.gitea4s.error.GiteaError
 import io.worxbend.gitea4s.http.{ArchiveParams, ContentsParams, GiteaDownloadRequest, GiteaRequests, GiteaResponseMapper}
 import sttp.capabilities.zio.ZioStreams
 import sttp.client4.*
-import zio.Task
+import zio.{Duration, Task, durationInt}
 import zio.stream.ZStream
+
+import java.util.concurrent.TimeoutException
 
 /** Streaming binary downloads, exposed only on `backend-zio`.
   *
@@ -27,6 +29,11 @@ import zio.stream.ZStream
   *
   * These streams are not retried: a partially consumed body cannot be safely
   * replayed. Use the buffered `GiteaClient` methods where retry matters.
+  *
+  * A stalled download fails rather than hanging. The budget measures the gap
+  * between chunks, not the total download time, so an archive that takes an
+  * hour to arrive is never penalised as long as it keeps arriving — see
+  * [[ZioGiteaDownloads.stallTimeout]].
   */
 trait GiteaDownloads:
   def rawFile(
@@ -50,7 +57,18 @@ trait GiteaDownloads:
       params: ArchiveParams = ArchiveParams.default
   ): ZStream[Any, GiteaError, Byte]
 
-final class ZioGiteaDownloads(config: GiteaConfig, backend: StreamBackend[Task, ZioStreams]) extends GiteaDownloads:
+final class ZioGiteaDownloads private (
+    config: GiteaConfig,
+    backend: StreamBackend[Task, ZioStreams],
+    stallTimeout: Duration
+) extends GiteaDownloads:
+  /** The published constructor. Unchanged: the stall budget is not a knob
+    * callers have asked for, and adding a parameter to this signature would
+    * break binary compatibility for 1.0.0.
+    */
+  def this(config: GiteaConfig, backend: StreamBackend[Task, ZioStreams]) =
+    this(config, backend, ZioGiteaDownloads.stallTimeout)
+
   override def rawFile(
       owner: String,
       repo: String,
@@ -94,7 +112,44 @@ final class ZioGiteaDownloads(config: GiteaConfig, backend: StreamBackend[Task, 
         .mapError(GiteaError.TransportError.apply)
         .map { response =>
           response.body match
-            case Right(bytes) => bytes.mapError(GiteaError.TransportError.apply)
+            case Right(bytes) =>
+              bytes
+                .mapError(GiteaError.TransportError.apply)
+                // The only limit on this path was `readTimeout`, which reaches
+                // the JDK as `HttpRequest.timeout` and stops applying the
+                // moment response headers arrive. So the path deliberately
+                // used for the *largest* bodies was the one with no backstop
+                // at all: a server that answered `200 OK` and then stopped
+                // sending held the consumer open indefinitely.
+                //
+                // `ZStream#timeoutFail` bounds each pull rather than the whole
+                // stream, which is what makes it safe here — a legitimately
+                // slow multi-gigabyte archive is never cut off, only a server
+                // that has stopped producing.
+                .timeoutFail(ZioGiteaDownloads.stalled(stallTimeout))(stallTimeout)
             case Left(errorBody) => ZStream.fail(GiteaResponseMapper.toError(response.copy(body = errorBody)))
         }
     }
+
+object ZioGiteaDownloads:
+  /** How long a running download may go without producing a single byte.
+    *
+    * Deliberately generous: this is a backstop against a connection that has
+    * stopped producing, not a latency target.
+    */
+  val stallTimeout: Duration = 5.minutes
+
+  /** Builds a downloader with a shorter budget, so the stall path can be
+    * exercised against a real clock instead of racing a `TestClock`.
+    */
+  private[zio] def withStallTimeout(
+      config: GiteaConfig,
+      backend: StreamBackend[Task, ZioStreams],
+      stallTimeout: Duration
+  ): ZioGiteaDownloads =
+    new ZioGiteaDownloads(config, backend, stallTimeout)
+
+  private def stalled(after: Duration): GiteaError =
+    GiteaError.TransportError(
+      new TimeoutException(s"Gitea download produced no data for $after")
+    )

--- a/backend-zio/test/src/io/worxbend/gitea4s/backend/zio/GiteaDownloadsSpec.scala
+++ b/backend-zio/test/src/io/worxbend/gitea4s/backend/zio/GiteaDownloadsSpec.scala
@@ -8,7 +8,7 @@ import sttp.client4.*
 import sttp.client4.impl.zio.RIOMonadAsyncError
 import sttp.client4.testing.{ResponseStub, StreamBackendStub}
 import sttp.model.StatusCode
-import zio.{Chunk, Ref, Task}
+import zio.{Chunk, Ref, Task, ZIO, durationInt}
 import zio.stream.ZStream
 import zio.test.*
 
@@ -43,6 +43,31 @@ object GiteaDownloadsSpec extends ZIOSpecDefault:
           drained <- reachedEnd.get
         yield assertTrue(head.contains(1.toByte), releaseCount == 1, !drained)
       },
+      test("fails a download that stops producing instead of hanging") {
+        // This path sends straight at the backend, so it never had the
+        // executor's attempt budget, and `readTimeout` reaches the JDK as
+        // `HttpRequest.timeout` — which stops applying once headers arrive.
+        // A server that answered 200 and then went quiet held the consumer
+        // open forever, on precisely the path meant for the largest bodies.
+        val body: ZStream[Any, Throwable, Byte] = ZStream.fromChunk(Chunk[Byte](1, 2, 3)) ++ ZStream.fromZIO(ZIO.never)
+
+        // A real clock and a short budget, rather than forking and nudging a
+        // `TestClock`: that races the forked fiber, so it passes when the
+        // fiber happens to reach the sleep first and hangs when it does not.
+        ZioGiteaDownloads
+          .withStallTimeout(config, stubBackend(body), 200.millis)
+          .archive("alice", "api", "main.zip")
+          .runCollect
+          .either
+          .map { result =>
+            assertTrue(
+              result.left.exists {
+                case GiteaError.TransportError(cause) => cause.isInstanceOf[java.util.concurrent.TimeoutException]
+                case _ => false
+              }
+            )
+          }
+      } @@ TestAspect.withLiveClock,
       test("maps a non-2xx download response to a typed GiteaError") {
         val errorBody = """{"message":"repository does not exist"}"""
         val backend =

--- a/client/src/io/worxbend/gitea4s/GiteaConfig.scala
+++ b/client/src/io/worxbend/gitea4s/GiteaConfig.scala
@@ -208,8 +208,8 @@ object GiteaConfig:
         Typesafe.maxRetries,
         defaultMaxRetries
       )
-      userAgent <- optionalStringFromConfig(section, qualified(path, Typesafe.userAgent), Typesafe.userAgent)
-      otp <- optionalStringFromConfig(section, qualified(path, Typesafe.otp), Typesafe.otp)
+      userAgent <- optionalHeaderFromConfig(section, qualified(path, Typesafe.userAgent), Typesafe.userAgent)
+      otp <- optionalHeaderFromConfig(section, qualified(path, Typesafe.otp), Typesafe.otp)
     yield
       val baseConfig = default(baseUrl, auth)
       baseConfig.copy(
@@ -267,16 +267,34 @@ object GiteaConfig:
         parseBaseUrl(raw, GiteaConfigError.InvalidEnv(Env.url, "must be an absolute HTTP(S) URL"))
 
   private def authFromEnv(env: Map[String, String]): Either[GiteaConfigError, Auth] =
-    nonBlank(env, Env.token) match
-      case Some(token) => Right(Auth.Token(token))
+    def header(name: String): Either[GiteaConfigError, Option[String]] =
+      headerSafe(nonBlank(env, name), GiteaConfigError.InvalidEnv(name, _))
+
+    for
+      token <- header(Env.token)
+      username <- header(Env.username)
+      password <- header(Env.password)
+      auth <- credentials(token, username, password, Env.username, Env.password, Env.token)
+    yield auth
+
+  private def credentials(
+      token: Option[String],
+      username: Option[String],
+      password: Option[String],
+      usernameLabel: String,
+      passwordLabel: String,
+      tokenLabel: String
+  ): Either[GiteaConfigError, Auth] =
+    token match
+      case Some(value) => Right(Auth.Token(value))
       case None =>
-        (nonBlank(env, Env.username), nonBlank(env, Env.password)) match
-          case (Some(username), Some(password)) => Right(Auth.Basic(username, password))
+        (username, password) match
+          case (Some(user), Some(secret)) => Right(Auth.Basic(user, secret))
           case (None, None) => Right(Auth.Anonymous)
           case _ =>
             Left(
               GiteaConfigError.InvalidCredentialEnv(
-                s"${Env.username} and ${Env.password} must be set together when ${Env.token} is absent"
+                s"$usernameLabel and $passwordLabel must be set together when $tokenLabel is absent"
               )
             )
 
@@ -333,24 +351,16 @@ object GiteaConfig:
     val usernamePath = qualified(rootPath, Typesafe.username)
     val passwordPath = qualified(rootPath, Typesafe.password)
 
-    optionalStringFromConfig(config, tokenPath, Typesafe.token).flatMap {
-      case Some(token) => Right(Auth.Token(token))
-      case None =>
-        (
-          optionalStringFromConfig(config, usernamePath, Typesafe.username),
-          optionalStringFromConfig(config, passwordPath, Typesafe.password)
-        ) match
-          case (Right(Some(username)), Right(Some(password))) => Right(Auth.Basic(username, password))
-          case (Right(None), Right(None)) => Right(Auth.Anonymous)
-          case (Right(_), Right(_)) =>
-            Left(
-              GiteaConfigError.InvalidCredentialEnv(
-                s"$usernamePath and $passwordPath must be set together when $tokenPath is absent"
-              )
-            )
-          case (Left(error), _) => Left(error)
-          case (_, Left(error)) => Left(error)
-    }
+    def header(path: String, key: String): Either[GiteaConfigError, Option[String]] =
+      optionalStringFromConfig(config, path, key)
+        .flatMap(value => headerSafe(value, GiteaConfigError.InvalidConfig(path, _)))
+
+    for
+      token <- header(tokenPath, Typesafe.token)
+      username <- header(usernamePath, Typesafe.username)
+      password <- header(passwordPath, Typesafe.password)
+      auth <- credentials(token, username, password, usernamePath, passwordPath, tokenPath)
+    yield auth
 
   private def positiveIntFromConfig(
       config: Config,
@@ -460,3 +470,41 @@ object GiteaConfig:
   // other reader here already compensated individually with `raw.trim`.
   private def nonBlank(env: Map[String, String], name: String): Option[String] =
     env.get(name).map(_.trim).filter(_.nonEmpty)
+
+  /** Rejects a value that cannot legally become an HTTP header.
+    *
+    * Trimming, above, only strips the ends. A CR or LF in the *middle* of a
+    * token survived into `s"token $value"` and failed later — as an untyped
+    * `IllegalArgumentException` from the JDK that quotes the credential back,
+    * after the request had already been retried. On a backend that does not
+    * validate, an embedded newline is header injection rather than a crash.
+    *
+    * Checking at parse time turns all of that into one typed error, raised
+    * where the setting is named. It covers the values that become header
+    * content: the credentials, the user agent, and the one-time password.
+    *
+    * Scope limit: `GiteaConfig.withToken` and `Auth.Token(...)` are public and
+    * construct a config without going through here, so this hardens the two
+    * parsing entry points, not every way to build a `GiteaConfig`.
+    */
+  private def headerSafe(
+      value: Option[String],
+      invalid: String => GiteaConfigError
+  ): Either[GiteaConfigError, Option[String]] =
+    value match
+      case Some(raw) if raw.exists(isControlCharacter) =>
+        // Names the setting, never the value: this runs on secrets.
+        Left(invalid("must not contain control characters"))
+      case other => Right(other)
+
+  private def isControlCharacter(character: Char): Boolean =
+    character.isControl
+
+  /** Reads a HOCON string that will be sent as a header value. */
+  private def optionalHeaderFromConfig(
+      config: Config,
+      path: String,
+      key: String
+  ): Either[GiteaConfigError, Option[String]] =
+    optionalStringFromConfig(config, path, key)
+      .flatMap(value => headerSafe(value, GiteaConfigError.InvalidConfig(path, _)))

--- a/client/src/io/worxbend/gitea4s/http/GiteaRequests.scala
+++ b/client/src/io/worxbend/gitea4s/http/GiteaRequests.scala
@@ -1,6 +1,7 @@
 package io.worxbend.gitea4s.http
 
 import io.worxbend.gitea4s.GiteaConfig
+import io.worxbend.gitea4s.error.GiteaError
 import io.worxbend.gitea4s.model.{
   AddTimeOption,
   AnnotatedTag,
@@ -60,7 +61,7 @@ import io.worxbend.gitea4s.model.{
   WatchInfo
 }
 import sttp.client4.*
-import sttp.model.{MediaType, Method, Uri}
+import sttp.model.{MediaType, Uri}
 import zio.Chunk
 import zio.json.*
 
@@ -85,15 +86,7 @@ object GiteaRequests:
     )
 
   def userStopwatches(config: GiteaConfig, page: Int = 1): GiteaRequest[Page[StopWatch]] =
-    val pageSize = config.pageSize
-
-    get(
-      config,
-      GiteaEndpoints.userGetStopWatches,
-      List("user", "stopwatches"),
-      pageQuery(page, pageSize),
-      response => GiteaResponseMapper.decodePage[StopWatch](response, page, pageSize)
-    )
+    paginated[StopWatch](config, GiteaEndpoints.userGetStopWatches, List("user", "stopwatches"), page)
 
   def repository(config: GiteaConfig, owner: String, repo: String): GiteaRequest[Repository] =
     get(
@@ -114,7 +107,7 @@ object GiteaRequests:
     )
 
   def organizationMembers(config: GiteaConfig, org: String, page: Int = 1): GiteaRequest[Page[User]] =
-    paginatedUsers(
+    paginated[User](
       config = config,
       endpoint = GiteaEndpoints.orgListMembers,
       path = List("orgs", org, "members"),
@@ -122,7 +115,7 @@ object GiteaRequests:
     )
 
   def organizationPublicMembers(config: GiteaConfig, org: String, page: Int = 1): GiteaRequest[Page[User]] =
-    paginatedUsers(
+    paginated[User](
       config = config,
       endpoint = GiteaEndpoints.orgListPublicMembers,
       path = List("orgs", org, "public_members"),
@@ -194,7 +187,7 @@ object GiteaRequests:
     )
 
   def repoStargazers(config: GiteaConfig, owner: String, repo: String, page: Int = 1): GiteaRequest[Page[User]] =
-    paginatedUsers(
+    paginated[User](
       config = config,
       endpoint = GiteaEndpoints.repoListStargazers,
       path = List("repos", owner, repo, "stargazers"),
@@ -202,7 +195,7 @@ object GiteaRequests:
     )
 
   def repoSubscribers(config: GiteaConfig, owner: String, repo: String, page: Int = 1): GiteaRequest[Page[User]] =
-    paginatedUsers(
+    paginated[User](
       config = config,
       endpoint = GiteaEndpoints.repoListSubscribers,
       path = List("repos", owner, repo, "subscribers"),
@@ -210,26 +203,10 @@ object GiteaRequests:
     )
 
   def repoBranches(config: GiteaConfig, owner: String, repo: String, page: Int = 1): GiteaRequest[Page[Branch]] =
-    val pageSize = config.pageSize
-
-    get(
-      config,
-      GiteaEndpoints.repoListBranches,
-      List("repos", owner, repo, "branches"),
-      pageQuery(page, pageSize),
-      response => GiteaResponseMapper.decodePage[Branch](response, page, pageSize)
-    )
+    paginated[Branch](config, GiteaEndpoints.repoListBranches, List("repos", owner, repo, "branches"), page)
 
   def repoTags(config: GiteaConfig, owner: String, repo: String, page: Int = 1): GiteaRequest[Page[Tag]] =
-    val pageSize = config.pageSize
-
-    get(
-      config,
-      GiteaEndpoints.repoListTags,
-      List("repos", owner, repo, "tags"),
-      pageQuery(page, pageSize),
-      response => GiteaResponseMapper.decodePage[Tag](response, page, pageSize)
-    )
+    paginated[Tag](config, GiteaEndpoints.repoListTags, List("repos", owner, repo, "tags"), page)
 
   def repoLanguages(config: GiteaConfig, owner: String, repo: String): GiteaRequest[LanguageStatistics] =
     get(
@@ -373,7 +350,7 @@ object GiteaRequests:
     )
 
   def repoCollaborators(config: GiteaConfig, owner: String, repo: String, page: Int = 1): GiteaRequest[Page[User]] =
-    paginatedUsers(
+    paginated[User](
       config = config,
       endpoint = GiteaEndpoints.repoListCollaborators,
       path = List("repos", owner, repo, "collaborators"),
@@ -409,15 +386,7 @@ object GiteaRequests:
     )
 
   def repoTeams(config: GiteaConfig, owner: String, repo: String, page: Int = 1): GiteaRequest[Page[Team]] =
-    val pageSize = config.pageSize
-
-    get(
-      config,
-      GiteaEndpoints.repoListTeams,
-      List("repos", owner, repo, "teams"),
-      pageQuery(page, pageSize),
-      response => GiteaResponseMapper.decodePage[Team](response, page, pageSize)
-    )
+    paginated[Team](config, GiteaEndpoints.repoListTeams, List("repos", owner, repo, "teams"), page)
 
   def repoTeam(config: GiteaConfig, owner: String, repo: String, team: String): GiteaRequest[Team] =
     get(
@@ -889,15 +858,7 @@ object GiteaRequests:
       index: Long,
       page: Int = 1
   ): GiteaRequest[Page[PullReview]] =
-    val pageSize = config.pageSize
-
-    get(
-      config,
-      GiteaEndpoints.repoListPullReviews,
-      List("repos", owner, repo, "pulls", index.toString, "reviews"),
-      pageQuery(page, pageSize),
-      response => GiteaResponseMapper.decodePage[PullReview](response, page, pageSize)
-    )
+    paginated[PullReview](config, GiteaEndpoints.repoListPullReviews, List("repos", owner, repo, "pulls", index.toString, "reviews"), page)
 
   def createPullReview(
       config: GiteaConfig,
@@ -1275,15 +1236,7 @@ object GiteaRequests:
 
   def issueBlocks(config: GiteaConfig, owner: String, repo: String, index: Long, page: Int = 1)
       : GiteaRequest[Page[Issue]] =
-    val pageSize = config.pageSize
-
-    get(
-      config,
-      GiteaEndpoints.issueListBlocks,
-      List("repos", owner, repo, "issues", index.toString, "blocks"),
-      pageQuery(page, pageSize),
-      response => GiteaResponseMapper.decodePage[Issue](response, page, pageSize)
-    )
+    paginated[Issue](config, GiteaEndpoints.issueListBlocks, List("repos", owner, repo, "issues", index.toString, "blocks"), page)
 
   def createIssueBlocking(
       config: GiteaConfig,
@@ -1317,15 +1270,7 @@ object GiteaRequests:
 
   def issueDependencies(config: GiteaConfig, owner: String, repo: String, index: Long, page: Int = 1)
       : GiteaRequest[Page[Issue]] =
-    val pageSize = config.pageSize
-
-    get(
-      config,
-      GiteaEndpoints.issueListIssueDependencies,
-      List("repos", owner, repo, "issues", index.toString, "dependencies"),
-      pageQuery(page, pageSize),
-      response => GiteaResponseMapper.decodePage[Issue](response, page, pageSize)
-    )
+    paginated[Issue](config, GiteaEndpoints.issueListIssueDependencies, List("repos", owner, repo, "issues", index.toString, "dependencies"), page)
 
   def createIssueDependency(
       config: GiteaConfig,
@@ -1458,15 +1403,7 @@ object GiteaRequests:
 
   def issueReactions(config: GiteaConfig, owner: String, repo: String, index: Long, page: Int = 1)
       : GiteaRequest[Page[Reaction]] =
-    val pageSize = config.pageSize
-
-    get(
-      config,
-      GiteaEndpoints.issueGetIssueReactions,
-      List("repos", owner, repo, "issues", index.toString, "reactions"),
-      pageQuery(page, pageSize),
-      response => GiteaResponseMapper.decodePage[Reaction](response, page, pageSize)
-    )
+    paginated[Reaction](config, GiteaEndpoints.issueGetIssueReactions, List("repos", owner, repo, "issues", index.toString, "reactions"), page)
 
   def postIssueReaction(
       config: GiteaConfig,
@@ -1500,15 +1437,7 @@ object GiteaRequests:
 
   def issueSubscriptions(config: GiteaConfig, owner: String, repo: String, index: Long, page: Int = 1)
       : GiteaRequest[Page[User]] =
-    val pageSize = config.pageSize
-
-    get(
-      config,
-      GiteaEndpoints.issueSubscriptions,
-      List("repos", owner, repo, "issues", index.toString, "subscriptions"),
-      pageQuery(page, pageSize),
-      response => GiteaResponseMapper.decodePage[User](response, page, pageSize)
-    )
+    paginated[User](config, GiteaEndpoints.issueSubscriptions, List("repos", owner, repo, "issues", index.toString, "subscriptions"), page)
 
   def issueSubscription(config: GiteaConfig, owner: String, repo: String, index: Long): GiteaRequest[WatchInfo] =
     get(
@@ -1658,7 +1587,7 @@ object GiteaRequests:
     )
 
   def userFollowers(config: GiteaConfig, username: String, page: Int = 1): GiteaRequest[Page[User]] =
-    paginatedUsers(
+    paginated[User](
       config = config,
       endpoint = GiteaEndpoints.userListFollowers,
       path = List("users", username, "followers"),
@@ -1666,7 +1595,7 @@ object GiteaRequests:
     )
 
   def userFollowing(config: GiteaConfig, username: String, page: Int = 1): GiteaRequest[Page[User]] =
-    paginatedUsers(
+    paginated[User](
       config = config,
       endpoint = GiteaEndpoints.userListFollowing,
       path = List("users", username, "following"),
@@ -1735,24 +1664,48 @@ object GiteaRequests:
   ): PartialRequest[Either[String, String]] =
     if config.otp.isDefined then request.followRedirects(false) else request
 
-  private def get[A](
+  /** Finishes a JSON request with the four things every endpoint shares: the
+    * string response, the read timeout, the common headers, and the retry
+    * policy implied by the verb.
+    *
+    * These four lines were repeated verbatim in all nine verb helpers below,
+    * which meant a change to any of them had to be made nine times to take
+    * effect everywhere. The read timeout was the exposed one — nothing asserts
+    * it, so an omission would not have shown up as a failing test.
+    */
+  private def jsonCall[A](
       config: GiteaConfig,
       endpoint: GiteaEndpoint,
-      path: List[String],
-      query: List[(String, String)],
-      decode: Response[String] => Either[io.worxbend.gitea4s.error.GiteaError, A],
+      request: Request[Either[String, String]],
+      decode: Response[String] => Either[GiteaError, A],
       accept: String = MediaType.ApplicationJson.toString
   ): GiteaRequest[A] =
     GiteaRequest(
       endpoint = endpoint,
-      request = jsonRequest(config)
-        .get(apiUri(config.baseUrl, path, query))
+      request = request
         .response(stringResponse)
         .readTimeout(config.timeout)
         .headers(commonHeaders(config, accept)),
       decode = decode,
       retryable = GiteaRequest.isReadOnly(endpoint)
     )
+
+  /** The JSON body every write helper attaches, spelled once. */
+  private def withJson(
+      request: Request[Either[String, String]],
+      json: String
+  ): Request[Either[String, String]] =
+    request.body(json).contentType(MediaType.ApplicationJson)
+
+  private def get[A](
+      config: GiteaConfig,
+      endpoint: GiteaEndpoint,
+      path: List[String],
+      query: List[(String, String)],
+      decode: Response[String] => Either[GiteaError, A],
+      accept: String = MediaType.ApplicationJson.toString
+  ): GiteaRequest[A] =
+    jsonCall(config, endpoint, jsonRequest(config).get(apiUri(config.baseUrl, path, query)), decode, accept)
 
   private def getBytes(
       config: GiteaConfig,
@@ -1789,24 +1742,15 @@ object GiteaRequests:
       endpoint: GiteaEndpoint,
       path: List[String],
       query: List[(String, String)],
-      decode: Response[String] => Either[io.worxbend.gitea4s.error.GiteaError, A]
+      decode: Response[String] => Either[GiteaError, A]
   ): GiteaRequest[A] =
-    GiteaRequest(
-      endpoint = endpoint,
-      request = jsonRequest(config)
-        .post(apiUri(config.baseUrl, path, query))
-        .response(stringResponse)
-        .readTimeout(config.timeout)
-        .headers(commonHeaders(config)),
-      decode = decode,
-      retryable = GiteaRequest.isReadOnly(endpoint)
-    )
+    jsonCall(config, endpoint, jsonRequest(config).post(apiUri(config.baseUrl, path, query)), decode)
 
   private def post[A](
       config: GiteaConfig,
       endpoint: GiteaEndpoint,
       path: List[String],
-      decode: Response[String] => Either[io.worxbend.gitea4s.error.GiteaError, A]
+      decode: Response[String] => Either[GiteaError, A]
   ): GiteaRequest[A] =
     post(config, endpoint, path, Nil, decode)
 
@@ -1815,131 +1759,60 @@ object GiteaRequests:
       endpoint: GiteaEndpoint,
       path: List[String],
       json: String,
-      decode: Response[String] => Either[io.worxbend.gitea4s.error.GiteaError, A]
+      decode: Response[String] => Either[GiteaError, A]
   ): GiteaRequest[A] =
-    GiteaRequest(
-      endpoint = endpoint,
-      request = jsonRequest(config)
-        .post(apiUri(config.baseUrl, path, Nil))
-        .body(json)
-        .contentType(MediaType.ApplicationJson)
-        .response(stringResponse)
-        .readTimeout(config.timeout)
-        .headers(commonHeaders(config)),
-      decode = decode,
-      retryable = GiteaRequest.isReadOnly(endpoint)
-    )
+    jsonCall(config, endpoint, withJson(jsonRequest(config).post(apiUri(config.baseUrl, path, Nil)), json), decode)
 
   private def putJson[A](
       config: GiteaConfig,
       endpoint: GiteaEndpoint,
       path: List[String],
       json: String,
-      decode: Response[String] => Either[io.worxbend.gitea4s.error.GiteaError, A]
+      decode: Response[String] => Either[GiteaError, A]
   ): GiteaRequest[A] =
-    GiteaRequest(
-      endpoint = endpoint,
-      request = jsonRequest(config)
-        .put(apiUri(config.baseUrl, path, Nil))
-        .body(json)
-        .contentType(MediaType.ApplicationJson)
-        .response(stringResponse)
-        .readTimeout(config.timeout)
-        .headers(commonHeaders(config)),
-      decode = decode,
-      retryable = GiteaRequest.isReadOnly(endpoint)
-    )
+    jsonCall(config, endpoint, withJson(jsonRequest(config).put(apiUri(config.baseUrl, path, Nil)), json), decode)
 
   private def put[A](
       config: GiteaConfig,
       endpoint: GiteaEndpoint,
       path: List[String],
-      decode: Response[String] => Either[io.worxbend.gitea4s.error.GiteaError, A]
+      decode: Response[String] => Either[GiteaError, A]
   ): GiteaRequest[A] =
-    GiteaRequest(
-      endpoint = endpoint,
-      request = jsonRequest(config)
-        .put(apiUri(config.baseUrl, path, Nil))
-        .response(stringResponse)
-        .readTimeout(config.timeout)
-        .headers(commonHeaders(config)),
-      decode = decode,
-      retryable = GiteaRequest.isReadOnly(endpoint)
-    )
+    jsonCall(config, endpoint, jsonRequest(config).put(apiUri(config.baseUrl, path, Nil)), decode)
 
   private def patchJson[A](
       config: GiteaConfig,
       endpoint: GiteaEndpoint,
       path: List[String],
       json: String,
-      decode: Response[String] => Either[io.worxbend.gitea4s.error.GiteaError, A]
+      decode: Response[String] => Either[GiteaError, A]
   ): GiteaRequest[A] =
-    GiteaRequest(
-      endpoint = endpoint,
-      request = jsonRequest(config)
-        .patch(apiUri(config.baseUrl, path, Nil))
-        .body(json)
-        .contentType(MediaType.ApplicationJson)
-        .response(stringResponse)
-        .readTimeout(config.timeout)
-        .headers(commonHeaders(config)),
-      decode = decode,
-      retryable = GiteaRequest.isReadOnly(endpoint)
-    )
+    jsonCall(config, endpoint, withJson(jsonRequest(config).patch(apiUri(config.baseUrl, path, Nil)), json), decode)
 
   private def patch[A](
       config: GiteaConfig,
       endpoint: GiteaEndpoint,
       path: List[String],
-      decode: Response[String] => Either[io.worxbend.gitea4s.error.GiteaError, A]
+      decode: Response[String] => Either[GiteaError, A]
   ): GiteaRequest[A] =
-    GiteaRequest(
-      endpoint = endpoint,
-      request = jsonRequest(config)
-        .patch(apiUri(config.baseUrl, path, Nil))
-        .response(stringResponse)
-        .readTimeout(config.timeout)
-        .headers(commonHeaders(config)),
-      decode = decode,
-      retryable = GiteaRequest.isReadOnly(endpoint)
-    )
+    jsonCall(config, endpoint, jsonRequest(config).patch(apiUri(config.baseUrl, path, Nil)), decode)
 
   private def delete[A](
       config: GiteaConfig,
       endpoint: GiteaEndpoint,
       path: List[String],
-      decode: Response[String] => Either[io.worxbend.gitea4s.error.GiteaError, A]
+      decode: Response[String] => Either[GiteaError, A]
   ): GiteaRequest[A] =
-    GiteaRequest(
-      endpoint = endpoint,
-      request = jsonRequest(config)
-        .delete(apiUri(config.baseUrl, path, Nil))
-        .response(stringResponse)
-        .readTimeout(config.timeout)
-        .headers(commonHeaders(config)),
-      decode = decode,
-      retryable = GiteaRequest.isReadOnly(endpoint)
-    )
+    jsonCall(config, endpoint, jsonRequest(config).delete(apiUri(config.baseUrl, path, Nil)), decode)
 
   private def deleteJson[A](
       config: GiteaConfig,
       endpoint: GiteaEndpoint,
       path: List[String],
       json: String,
-      decode: Response[String] => Either[io.worxbend.gitea4s.error.GiteaError, A]
+      decode: Response[String] => Either[GiteaError, A]
   ): GiteaRequest[A] =
-    GiteaRequest(
-      endpoint = endpoint,
-      request = jsonRequest(config)
-        .method(Method.DELETE, apiUri(config.baseUrl, path, Nil))
-        .body(json)
-        .contentType(MediaType.ApplicationJson)
-        .response(stringResponse)
-        .readTimeout(config.timeout)
-        .headers(commonHeaders(config)),
-      decode = decode,
-      retryable = GiteaRequest.isReadOnly(endpoint)
-    )
+    jsonCall(config, endpoint, withJson(jsonRequest(config).delete(apiUri(config.baseUrl, path, Nil)), json), decode)
 
   private def apiUri(baseUrl: Uri, path: List[String], query: List[(String, String)]): Uri =
     baseUrl.addPath(List("api", "v1") ++ path).addParams(query*)
@@ -1960,17 +1833,13 @@ object GiteaRequests:
       params.createdBy.map("created_by" -> _),
       params.assignedBy.map("assigned_by" -> _),
       params.mentionedBy.map("mentioned_by" -> _),
-      Some("page" -> page.toString),
-      Some("limit" -> pageSize.toString)
-    ).flatten
+    ).flatten ++ pageQuery(page, pageSize)
 
   private def userSearchQuery(params: UserSearchParams, page: Int, pageSize: Int): List[(String, String)] =
     List(
       params.q.map("q" -> _),
       params.uid.map(uid => "uid" -> uid.toString),
-      Some("page" -> page.toString),
-      Some("limit" -> pageSize.toString)
-    ).flatten
+    ).flatten ++ pageQuery(page, pageSize)
 
   private def pullRequestQuery(params: PullRequestListParams, page: Int, pageSize: Int): List[(String, String)] =
     List(
@@ -1979,17 +1848,13 @@ object GiteaRequests:
       params.sort.map(sort => "sort" -> sort.queryValue),
       params.milestone.map(value => "milestone" -> value.toString),
       params.poster.map("poster" -> _),
-      Some("page" -> page.toString),
-      Some("limit" -> pageSize.toString)
-    ).flatten ++ params.labels.map(label => "labels" -> label.toString)
+    ).flatten ++ pageQuery(page, pageSize) ++ params.labels.map(label => "labels" -> label.toString)
 
   private def releaseQuery(params: ReleaseListParams, page: Int, pageSize: Int): List[(String, String)] =
     List(
       params.draft.map(value => "draft" -> value.toString),
       params.preRelease.map(value => "pre-release" -> value.toString),
-      Some("page" -> page.toString),
-      Some("limit" -> pageSize.toString)
-    ).flatten
+    ).flatten ++ pageQuery(page, pageSize)
 
   private def pullRequestFilesQuery(
       params: PullRequestFilesParams,
@@ -1999,18 +1864,14 @@ object GiteaRequests:
     List(
       params.skipTo.map("skip-to" -> _),
       params.whitespace.map(value => "whitespace" -> value.queryValue),
-      Some("page" -> page.toString),
-      Some("limit" -> pageSize.toString)
-    ).flatten
+    ).flatten ++ pageQuery(page, pageSize)
 
   private def pullRequestCommitsQuery(
       params: PullRequestCommitsParams,
       page: Int,
       pageSize: Int
   ): List[(String, String)] =
-    List(
-      Some("page" -> page.toString),
-      Some("limit" -> pageSize.toString),
+    pageQuery(page, pageSize) ++ List(
       params.verification.map(value => "verification" -> value.toString),
       params.files.map(value => "files" -> value.toString)
     ).flatten
@@ -2023,9 +1884,7 @@ object GiteaRequests:
     List(
       params.sort.map(sort => "sort" -> sort.queryValue),
       params.state.map(state => "state" -> state.queryValue),
-      Some("page" -> page.toString),
-      Some("limit" -> pageSize.toString)
-    ).flatten
+    ).flatten ++ pageQuery(page, pageSize)
 
   private def singleCommitQuery(params: SingleCommitParams): List[(String, String)] =
     List(
@@ -2058,9 +1917,7 @@ object GiteaRequests:
       params.all.map(value => "all" -> value.toString),
       params.since.map(value => "since" -> value.toString),
       params.before.map(value => "before" -> value.toString),
-      Some("page" -> page.toString),
-      Some("limit" -> pageSize.toString)
-    ).flatten ++
+    ).flatten ++ pageQuery(page, pageSize) ++
       params.statusTypes.map(statusType => "status-types" -> statusType.queryValue) ++
       params.subjectTypes.map(subjectType => "subject-type" -> subjectType.queryValue)
 
@@ -2078,9 +1935,7 @@ object GiteaRequests:
     List(
       params.since.map(value => "since" -> value.toString),
       params.before.map(value => "before" -> value.toString),
-      Some("page" -> page.toString),
-      Some("limit" -> pageSize.toString)
-    ).flatten
+    ).flatten ++ pageQuery(page, pageSize)
 
   private def trackedTimeQuery(
       params: IssueTrackedTimeListParams,
@@ -2091,19 +1946,26 @@ object GiteaRequests:
       params.user.map("user" -> _),
       params.since.map(value => "since" -> value.toString),
       params.before.map(value => "before" -> value.toString),
-      Some("page" -> page.toString),
-      Some("limit" -> pageSize.toString)
-    ).flatten
+    ).flatten ++ pageQuery(page, pageSize)
 
   private def nonEmptyCsv(name: String, values: zio.Chunk[String]): Option[(String, String)] =
     Option.when(values.nonEmpty)(name -> values.mkString(","))
 
-  private def paginatedUsers(
+  /** A plain paged GET: one whose only query parameters are `page` and `limit`.
+    *
+    * This was `paginatedUsers`, fixed to `Page[User]` even though nothing in
+    * its body depended on the element type — `GiteaResponseMapper.decodePage`
+    * is already generic. Every other paged endpoint therefore repeated the
+    * same six lines, differing only in the type argument, and each copy
+    * restated the `page`/`pageSize` correspondence that has to hold between
+    * the query sent and the `Page` returned.
+    */
+  private def paginated[A: JsonDecoder](
       config: GiteaConfig,
       endpoint: GiteaEndpoint,
       path: List[String],
       page: Int
-  ): GiteaRequest[Page[User]] =
+  ): GiteaRequest[Page[A]] =
     val pageSize = config.pageSize
 
     get(
@@ -2111,7 +1973,7 @@ object GiteaRequests:
       endpoint,
       path,
       pageQuery(page, pageSize),
-      response => GiteaResponseMapper.decodePage[User](response, page, pageSize)
+      response => GiteaResponseMapper.decodePage[A](response, page, pageSize)
     )
 
   private def pageQuery(page: Int, pageSize: Int): List[(String, String)] =

--- a/client/src/io/worxbend/gitea4s/http/GiteaResponseMapper.scala
+++ b/client/src/io/worxbend/gitea4s/http/GiteaResponseMapper.scala
@@ -13,12 +13,16 @@ import java.time.{Instant, ZonedDateTime}
 import scala.util.Try
 
 object GiteaResponseMapper:
-  /** How much of a failing response body is kept on the returned error.
+  /** How much server-supplied text is kept on the returned error.
     *
     * The body is genuinely useful — Gitea puts validation detail in it — but a
     * `GiteaError` is a value users log, and without a ceiling a single failed
     * request could put a multi-megabyte payload into a log line. Real 422
     * payloads run to a few kilobytes.
+    *
+    * Bounds both fields a `GiteaError` carries: the body and the message
+    * lifted out of it. Capping only the body would leave the ceiling defeated
+    * by moving the payload inside the JSON.
     */
   private val errorBodyLimit: Int = 8 * 1024
 
@@ -166,10 +170,19 @@ object GiteaResponseMapper:
         )
     }
 
+  /** The server's explanation of a failure, bounded like the body it came from.
+    *
+    * Every source here is server-controlled, so all three go through
+    * `truncate`. Capping only the body left the ceiling trivially defeated: a
+    * response of `{"message": "<4 MB>"}` put the whole payload on
+    * `GiteaError.message` while `body` was dutifully clipped to 8 KiB.
+    */
   private def errorMessage(response: Response[String]): String =
-    response.body.fromJson[GiteaErrorPayload].toOption.flatMap(_.message)
-      .orElse(response.header("message"))
-      .getOrElse(response.statusText)
+    truncate(
+      response.body.fromJson[GiteaErrorPayload].toOption.flatMap(_.message)
+        .orElse(response.header("message"))
+        .getOrElse(response.statusText)
+    )
 
   private def truncate(body: String): String =
     if body.length <= errorBodyLimit then body else body.take(errorBodyLimit)

--- a/client/src/io/worxbend/gitea4s/internal/GiteaRequestExecutor.scala
+++ b/client/src/io/worxbend/gitea4s/internal/GiteaRequestExecutor.scala
@@ -13,11 +13,11 @@ final class GiteaRequestExecutor(
     backend: Backend[Task],
     maxRetries: Int,
     observer: GiteaObserver = GiteaObserver.noop,
-    totalTimeout: Duration = GiteaRequestExecutor.defaultTotalTimeout
+    attemptTimeout: Duration = GiteaRequestExecutor.defaultAttemptTimeout
 ):
   def send[A](request: GiteaRequest[A]): IO[GiteaError, A] =
     val retries = math.max(0, maxRetries)
-    if observer eq GiteaObserver.noop then core(request, retries, null)
+    if observer eq GiteaObserver.noop then core(request, retries, GiteaRequestExecutor.AttemptRecorder.discarding)
     else
       // The telemetry holder is allocated only when somebody is listening, so
       // the default configuration keeps the zero-overhead path it documents.
@@ -28,11 +28,11 @@ final class GiteaRequestExecutor(
   private def core[A](
       request: GiteaRequest[A],
       retries: Int,
-      telemetry: GiteaRequestExecutor.Telemetry
+      recorder: GiteaRequestExecutor.AttemptRecorder
   ): IO[GiteaError, A] =
     if request.retryable && retries > 0 then
-      sendWithRetries(request, attempt = 1, remainingRetries = retries, telemetry)
-    else sendOnce(request, telemetry)
+      sendWithRetries(request, attempt = 1, remainingRetries = retries, recorder)
+    else sendOnce(request, recorder)
 
   private def observed[A](
       request: GiteaRequest[A],
@@ -74,14 +74,14 @@ final class GiteaRequestExecutor(
       request: GiteaRequest[A],
       attempt: Int,
       remainingRetries: Int,
-      telemetry: GiteaRequestExecutor.Telemetry
+      recorder: GiteaRequestExecutor.AttemptRecorder
   ): IO[GiteaError, A] =
-    sendOnce(request, telemetry).catchAll { error =>
+    sendOnce(request, recorder).catchAll { error =>
       if remainingRetries <= 0 then ZIO.fail(error)
       else
         retryDelay(error, attempt).flatMap {
           case Some(delay) =>
-            ZIO.sleep(delay) *> sendWithRetries(request, attempt + 1, remainingRetries - 1, telemetry)
+            ZIO.sleep(delay) *> sendWithRetries(request, attempt + 1, remainingRetries - 1, recorder)
           case None =>
             ZIO.fail(error)
         }
@@ -89,19 +89,26 @@ final class GiteaRequestExecutor(
 
   private def sendOnce[A](
       request: GiteaRequest[A],
-      telemetry: GiteaRequestExecutor.Telemetry
+      recorder: GiteaRequestExecutor.AttemptRecorder
   ): IO[GiteaError, A] =
     request.request
       .send(backend)
       .mapError(GiteaError.TransportError.apply)
       .flatMap { response =>
-        if telemetry ne null then telemetry.record(response.code.code)
+        recorder.record(response.code.code)
         ZIO.fromEither(request.decode(response))
       }
-      .timeoutFail(GiteaRequestExecutor.timedOut(totalTimeout))(totalTimeout)
+      .timeoutFail(GiteaRequestExecutor.attemptBudgetExhausted(attemptTimeout))(attemptTimeout)
 
   private def retryDelay(error: GiteaError, attempt: Int): UIO[Option[Duration]] =
     error match
+      // Checked ahead of the general transport case, which would otherwise
+      // catch it. An exhausted attempt budget means the connection stalled
+      // mid-body for minutes; that is the most expensive failure the client
+      // can have, and the condition least likely to have cleared by the time a
+      // retry re-runs it. Retrying turned a five-minute stall into twenty.
+      case GiteaError.TransportError(_: GiteaRequestExecutor.AttemptBudgetExhausted) =>
+        ZIO.succeed(None)
       case GiteaError.TransportError(_) =>
         jitteredBackoff(attempt).map(Some(_))
       case GiteaError.RateLimited(Some(resetAt), _) =>
@@ -159,11 +166,41 @@ object GiteaRequestExecutor:
     * It is deliberately far larger than a typical `GiteaConfig.timeout`: this
     * is a backstop against a stalled connection, not a latency target, and a
     * legitimately large `repos.archive` fetch must still be able to finish.
+    *
+    * It bounds one *attempt*, not the call. Because it is applied inside the
+    * retry loop it starts again on each attempt — but an exhausted budget is
+    * not itself retried (see `retryDelay`), so a call spends this budget at
+    * most once. A caller who wants a single deadline covering retries,
+    * backoff sleeps and all should wrap the call in ZIO's own `.timeout`.
     */
-  val defaultTotalTimeout: Duration = Duration.ofMinutes(5)
+  val defaultAttemptTimeout: Duration = Duration.ofMinutes(5)
 
-  private def timedOut(after: Duration): GiteaError =
-    GiteaError.TransportError(new TimeoutException(s"Gitea request exceeded the total time budget of $after"))
+  /** Raised when one attempt outlives [[defaultAttemptTimeout]].
+    *
+    * A distinct type purely so `retryDelay` can tell this apart from the
+    * transport failures that *are* worth retrying. It extends
+    * `TimeoutException` so that callers matching on the exception type — and
+    * sttp's own timeouts, which stay retryable — keep behaving as before.
+    */
+  private final class AttemptBudgetExhausted(message: String) extends TimeoutException(message)
+
+  private def attemptBudgetExhausted(after: Duration): GiteaError =
+    GiteaError.TransportError(new AttemptBudgetExhausted(s"Gitea request attempt exceeded its time budget of $after"))
+
+  /** Where each attempt reports the status it got back.
+    *
+    * The send path does not care whether anybody is listening, so it is handed
+    * a recorder rather than a nullable holder. Previously the default path
+    * passed `null` and every attempt paid for a `ne null` guard on the happy
+    * path to describe a contract that appeared in no type.
+    */
+  private sealed trait AttemptRecorder:
+    def record(code: Int): Unit
+
+  private object AttemptRecorder:
+    /** Shared and stateless, so the default path still allocates nothing. */
+    val discarding: AttemptRecorder = new AttemptRecorder:
+      def record(code: Int): Unit = ()
 
   /** Per-call scratch space for the facts an observer wants but the result type
     * does not carry: how many HTTP requests were issued, and what the last one
@@ -173,7 +210,7 @@ object GiteaRequestExecutor:
     * finished, so the two never race; `@volatile` covers the executor handing
     * the fiber between threads in between.
     */
-  private final class Telemetry:
+  private final class Telemetry extends AttemptRecorder:
     @volatile private var status: Int = -1
     @volatile private var count: Int = 0
 

--- a/client/test/src/io/worxbend/gitea4s/GiteaConfigSpec.scala
+++ b/client/test/src/io/worxbend/gitea4s/GiteaConfigSpec.scala
@@ -206,6 +206,63 @@ object GiteaConfigSpec extends ZIOSpecDefault:
           !message.contains("password-secret")
         )
       },
+      test("rejects a token with a control character in the middle") {
+        // Trimming only strips the ends. An embedded CR/LF used to survive
+        // into `Authorization: token ...` and fail later — as an untyped JDK
+        // exception quoting the credential, after being retried three times.
+        val result = GiteaConfig.fromEnv(baseEnv + (GiteaConfig.Env.token -> "ghp_abc\r\ndef"))
+        val message = result.left.toOption.map(_.toString).getOrElse("")
+
+        assertTrue(
+          result.isLeft,
+          message.contains(GiteaConfig.Env.token),
+          // The error names the setting, never the secret.
+          !message.contains("ghp_abc")
+        )
+      },
+      test("rejects basic credentials with a control character in the middle") {
+        val result =
+          GiteaConfig.fromEnv(
+            baseEnv ++ Map(
+              GiteaConfig.Env.username -> "alice",
+              GiteaConfig.Env.password -> "hun\u0000ter"
+            )
+          )
+        val message = result.left.toOption.map(_.toString).getOrElse("")
+
+        assertTrue(result.isLeft, message.contains(GiteaConfig.Env.password), !message.contains("hun"))
+      },
+      test("accepts a password containing spaces") {
+        // The guard rejects control characters, not everything unusual. A space
+        // is legal in a header value and ordinary in a passphrase, so this pins
+        // the boundary that the rejection tests would otherwise let drift.
+        val passphrase = "correct horse battery staple"
+        val result =
+          GiteaConfig.fromEnv(
+            baseEnv ++ Map(
+              GiteaConfig.Env.username -> "alice",
+              GiteaConfig.Env.password -> passphrase
+            )
+          )
+
+        assertTrue(result.map(_.auth) == Right(Auth.Basic("alice", passphrase)))
+      },
+      test("rejects a HOCON user-agent with a control character") {
+        val result = GiteaConfig.fromTypesafeString(
+          """gitea4s { url = "https://gitea.example", token = "t", user-agent = "bad\nagent" }"""
+        )
+        val message = result.left.toOption.map(_.toString).getOrElse("")
+
+        assertTrue(result.isLeft, message.contains("user-agent"))
+      },
+      test("rejects a HOCON otp with a control character") {
+        val result = GiteaConfig.fromTypesafeString(
+          """gitea4s { url = "https://gitea.example", token = "t", otp = "12\r\n34" }"""
+        )
+        val message = result.left.toOption.map(_.toString).getOrElse("")
+
+        assertTrue(result.isLeft, message.contains("otp"), !message.contains("1234"))
+      },
       test("trims whitespace around a token read from the environment") {
         // A secret read out of a file keeps its trailing newline. Untrimmed,
         // the JDK rejects the resulting header value with an exception that

--- a/client/test/src/io/worxbend/gitea4s/http/GiteaEndpointAuditSpec.scala
+++ b/client/test/src/io/worxbend/gitea4s/http/GiteaEndpointAuditSpec.scala
@@ -17,6 +17,7 @@ import io.worxbend.gitea4s.model.{
   SubmitPullReviewOptions
 }
 import sttp.client4.*
+import sttp.model.Uri
 import zio.Chunk
 import zio.test.*
 
@@ -924,8 +925,53 @@ object GiteaEndpointAuditSpec extends ZIOSpecDefault:
         val failures = pathEnumAudits.flatMap(auditPathEnum(swagger, _))
 
         assertTrue(failures.isEmpty) ?? failures.mkString("\n")
+      },
+      // The suites above audit whichever endpoints somebody remembered to
+      // register. These last two audit the catalog itself, so an endpoint
+      // cannot be added without being checked against the contract at all.
+      test("every endpoint in GiteaEndpoints.all resolves in plugin-redoc-2.yaml") {
+        val swagger = SwaggerAudit.load()
+        val failures = GiteaEndpoints.all.flatMap(auditEndpointIdentity(swagger, _))
+
+        assertTrue(failures.isEmpty) ?? failures.mkString("\n")
+      },
+      test("GiteaEndpoints.all lists every endpoint constant") {
+        val declared = GiteaEndpoints.all.map(_.operationId).sorted
+        val defined = definedEndpointConstants.map(_.operationId).sorted
+
+        assertTrue(declared == defined) ??
+          s"missing from all: ${defined.diff(declared)}; not defined as constants: ${declared.diff(defined)}"
       }
     )
+
+  /** The subset of [[auditEndpoint]] that needs no per-operation registration.
+    *
+    * [[auditEndpoint]] demands an entry in `expectedNonSuccessResponseLabels`
+    * and so can only run for endpoints somebody has enrolled. This checks the
+    * three facts that identify an operation — its id, verb and path — for
+    * every endpoint in the catalog, which is what catches a constant that has
+    * drifted from the spec or was never in it.
+    */
+  private def auditEndpointIdentity(swagger: SwaggerAudit, endpoint: GiteaEndpoint): List[String] =
+    swagger.operation(endpoint.path, endpoint.method) match
+      case Left(message) => List(s"${endpoint.operationId}: $message")
+      case Right(operation) =>
+        List(
+          compare("operationId", endpoint.operationId, operation.operationId),
+          compare("method", endpoint.method.toUpperCase, operation.method),
+          compare("path", endpoint.path, operation.path)
+        ).flatten.map(message => s"${endpoint.operationId}: $message")
+
+  /** Every `GiteaEndpoint` constant on the companion, found by reflection.
+    *
+    * A `val` in a Scala 3 `object` compiles to a no-argument getter, so asking
+    * the class for its zero-argument methods returning `GiteaEndpoint` finds
+    * the constants without anyone maintaining a second list of their names.
+    */
+  private def definedEndpointConstants: List[GiteaEndpoint] =
+    GiteaEndpoints.getClass.getMethods.toList
+      .filter(method => method.getReturnType == classOf[GiteaEndpoint] && method.getParameterCount == 0)
+      .map(_.invoke(GiteaEndpoints).asInstanceOf[GiteaEndpoint])
 
   private def auditEndpoint(swagger: SwaggerAudit, endpoint: GiteaEndpoint): List[String] =
     val expectedNonSuccessResponses = expectedNonSuccessResponseLabels.get(endpoint.operationId)
@@ -988,6 +1034,8 @@ object GiteaEndpointAuditSpec extends ZIOSpecDefault:
           compare("endpoint body presence", endpointHasBody, operation.hasRequestBody),
           compare("request body presence", requestHasBody, operation.hasRequestBody),
           compare("retryable", audited.request.retryable, expectedRetryable),
+          compare("request method", audited.request.request.method.method, endpoint.method.toUpperCase),
+          pathShapeFailure(endpoint, audited.request.request.uri),
           Option.when(audited.noBodyLifecyclePost && requestHasBody)("no-body lifecycle POST emitted a request body"),
           Option.when(audited.noBodyLifecyclePost && audited.request.request.header("Content-Type").nonEmpty)(
             "no-body lifecycle POST emitted Content-Type"
@@ -1109,6 +1157,38 @@ object GiteaEndpointAuditSpec extends ZIOSpecDefault:
 
   private def compare[A](label: String, actual: A, expected: A): Option[String] =
     Option.when(actual != expected)(s"$label actual=$actual expected=$expected")
+
+  /** Checks the URI a builder actually produced against the path template its
+    * endpoint declares.
+    *
+    * Without this the two are never compared to each other. `GiteaEndpoint`
+    * mirrors `plugin-redoc-2.yaml`, and every assertion above checks that
+    * mirror against the spec — but `GiteaRequests` builds the real URI from a
+    * separate list of segments, so a typo there (`"relases"` for `"releases"`)
+    * changes what goes on the wire while leaving all of the metadata audits
+    * green.
+    *
+    * Only the literal segments are compared. A segment containing `{` is a
+    * template the caller fills in, and its value is arbitrary — which is also
+    * what lets the two compound segments in the spec, `{sha}.{diffType}` and
+    * `{index}.{diffType}`, pass unexamined.
+    */
+  private def pathShapeFailure(endpoint: GiteaEndpoint, uri: Uri): Option[String] =
+    val expected = endpoint.path.split("/").toList.filter(_.nonEmpty)
+    val actual = uri.path.drop(config.baseUrl.path.size + apiPrefix.size)
+
+    if actual.size != expected.size then
+      Some(s"request path segment count actual=$actual expected=$expected")
+    else
+      expected
+        .zip(actual)
+        .collectFirst {
+          case (template, segment) if !template.contains("{") && template != segment =>
+            s"request path segment actual=$segment expected=$template (in $actual against ${endpoint.path})"
+        }
+
+  /** The two segments `GiteaRequests.apiUri` prepends to every path. */
+  private val apiPrefix: List[String] = List("api", "v1")
 
   private def compareSwagger[A](label: String, actual: A, expected: Either[String, A]): List[String] =
     expected.fold(

--- a/client/test/src/io/worxbend/gitea4s/http/GiteaRequestsSpec.scala
+++ b/client/test/src/io/worxbend/gitea4s/http/GiteaRequestsSpec.scala
@@ -4697,6 +4697,26 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
           }
         )
       },
+      test("every verb carries the configured read timeout") {
+        // The response type, read timeout, common headers and retry flag used
+        // to be repeated in each verb helper; they are now applied in one
+        // place. Nothing else asserts the read timeout, so dropping it during
+        // that merge would have been silent — a request would simply have
+        // fallen back to sttp's default instead of honouring GiteaConfig.
+        // One request per verb helper, so no helper can lose the timeout unnoticed.
+        val requests: List[GiteaRequest[?]] = List(
+          GiteaRequests.currentUser(config),
+          GiteaRequests.stopIssueStopwatch(config, "owner", "repo", 1),
+          GiteaRequests.addIssueTrackedTime(config, "owner", "repo", 1, AddTimeOption(time = 60)),
+          GiteaRequests.addIssueSubscription(config, "owner", "repo", 1, "alice"),
+          GiteaRequests.lockIssue(config, "owner", "repo", 1, LockIssueOption(lockReason = Some("spam"))),
+          GiteaRequests.moveIssuePin(config, "owner", "repo", 1, 2),
+          GiteaRequests.editIssueComment(config, "owner", "repo", 1, EditIssueComment(body = "b")),
+          GiteaRequests.deleteIssueReaction(config, "owner", "repo", 1, EditReactionOption(content = "+1"))
+        )
+
+        assertTrue(requests.forall(_.request.options.readTimeout == config.timeout))
+      },
       suite("GiteaRequestExecutor is the sole supported execution path for byte responses")(
         test("executes a string-typed GiteaRequest through GiteaRequestExecutor and decodes the response") {
           val userJson = """{"id":1,"login":"alice"}"""

--- a/client/test/src/io/worxbend/gitea4s/http/GiteaResponseMapperSpec.scala
+++ b/client/test/src/io/worxbend/gitea4s/http/GiteaResponseMapperSpec.scala
@@ -272,6 +272,22 @@ object GiteaResponseMapperSpec extends ZIOSpecDefault:
 
           assertTrue(result == Left(GiteaError.ServerError(500, "x" * 8192)))
         },
+        test("truncates an oversized message carried inside the error body") {
+          // The body cap alone was defeated by moving the payload into the
+          // JSON: `body` was clipped while `message`, lifted out of the same
+          // untrusted response, kept the whole thing.
+          val message = "y" * (100 * 1024)
+          val error = GiteaResponseMapper.toError(raw(s"""{"message":"$message"}""", StatusCode.UnprocessableEntity))
+
+          assertTrue(error.asInstanceOf[GiteaError.UnprocessableEntity].message == "y" * 8192)
+        },
+        test("truncates an oversized message sent in the header fallback") {
+          val error = GiteaResponseMapper.toError(
+            withHeaders("not json", StatusCode.BadRequest, "message" -> "z" * (100 * 1024))
+          )
+
+          assertTrue(error.asInstanceOf[GiteaError.BadRequest].message == "z" * 8192)
+        },
         test("truncates the body kept on a decode failure") {
           val body = "[" + ("\"not-an-int\"," * 5000).dropRight(1) + "]"
           val result = GiteaResponseMapper.decodeChunk[Int](ResponseStub(body, StatusCode.Ok))

--- a/client/test/src/io/worxbend/gitea4s/internal/GiteaRequestExecutorSpec.scala
+++ b/client/test/src/io/worxbend/gitea4s/internal/GiteaRequestExecutorSpec.scala
@@ -116,14 +116,14 @@ object GiteaRequestExecutorSpec extends ZIOSpecDefault:
         yield assertTrue(!request.retryable, events.head.attempts == 1)
       }
     ),
-    suite("total time budget")(
+    suite("attempt time budget")(
       test("a response that never arrives fails instead of hanging") {
         // `GiteaConfig.timeout` reaches the JDK as HttpRequest.timeout, which
         // stops applying once response headers arrive, so it cannot bound a
         // body that never ends. This budget can.
         val backend = BackendStub[Task](new RIOMonadAsyncError[Any]).whenAnyRequest.thenRespondF(_ => ZIO.never)
 
-        GiteaRequestExecutor(backend, maxRetries = 0, totalTimeout = Duration.fromMillis(200))
+        GiteaRequestExecutor(backend, maxRetries = 0, attemptTimeout = Duration.fromMillis(200))
           .send(GiteaRequests.currentUser(config))
           .either
           .map {
@@ -131,6 +131,35 @@ object GiteaRequestExecutorSpec extends ZIOSpecDefault:
               assertTrue(cause.isInstanceOf[java.util.concurrent.TimeoutException])
             case _ => assertTrue(false)
           }
+      } @@ TestAspect.withLiveClock,
+      test("an exhausted budget is surfaced, not retried") {
+        // The budget is applied per attempt, so a retried stall used to be
+        // paid for `maxRetries + 1` times over: a five-minute stall against
+        // the default configuration hung the caller for twenty. A stalled
+        // connection is also the condition least likely to have cleared by
+        // the time the retry runs, so the attempts bought nothing.
+        val request = GiteaRequests.currentUser(config)
+
+        for
+          // Counted at the backend, not on the telemetry event: `attempts` only
+          // advances when a response arrives, and here none ever does, so it
+          // reads 1 whether the stall was retried or not.
+          sent <- Ref.make(0)
+          backend = BackendStub[Task](new RIOMonadAsyncError[Any]).whenAnyRequest
+            .thenRespondF(_ => sent.update(_ + 1) *> ZIO.never)
+          result <- GiteaRequestExecutor(
+            backend,
+            maxRetries = 3,
+            attemptTimeout = Duration.fromMillis(200)
+          ).send(request).either
+          attempts <- sent.get
+        yield assertTrue(
+          // A retryable GET with three retries available: without the guard
+          // this reaches the backend four times and costs four budgets.
+          request.retryable,
+          result.isLeft,
+          attempts == 1
+        )
       } @@ TestAspect.withLiveClock
     ),
     suite("telemetry")(

--- a/core/test/src/io/worxbend/gitea4s/model/CoreModelsSpec.scala
+++ b/core/test/src/io/worxbend/gitea4s/model/CoreModelsSpec.scala
@@ -6,6 +6,8 @@ import zio.json.*
 import zio.json.ast.Json
 import zio.test.*
 
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path, Paths}
 import java.time.Instant
 
 object CoreModelsSpec extends ZIOSpecDefault:
@@ -20,92 +22,62 @@ object CoreModelsSpec extends ZIOSpecDefault:
       sampleKeys: Set[String]
   )
 
-  private val schemaChecklistSwaggerFields = Map(
-    "Attachment" -> Set("browser_download_url", "created_at", "download_count", "id", "name", "size", "uuid"),
-    "RepoCollaboratorPermission" -> Set("permission", "role_name", "user"),
-    "Team" -> Set(
-      "can_create_org_repo",
-      "description",
-      "id",
-      "includes_all_repositories",
-      "name",
-      "organization",
-      "permission",
-      "units",
-      "units_map"
-    ),
-    "TagProtection" -> Set(
-      "created_at",
-      "id",
-      "name_pattern",
-      "updated_at",
-      "whitelist_teams",
-      "whitelist_usernames"
-    ),
-    "BranchProtection" -> Set(
-      "approvals_whitelist_teams",
-      "approvals_whitelist_username",
-      "block_admin_merge_override",
-      "block_on_official_review_requests",
-      "block_on_outdated_branch",
-      "block_on_rejected_reviews",
-      "branch_name",
-      "created_at",
-      "dismiss_stale_approvals",
-      "enable_approvals_whitelist",
-      "enable_force_push",
-      "enable_force_push_allowlist",
-      "enable_merge_whitelist",
-      "enable_push",
-      "enable_push_whitelist",
-      "enable_status_check",
-      "force_push_allowlist_deploy_keys",
-      "force_push_allowlist_teams",
-      "force_push_allowlist_usernames",
-      "ignore_stale_approvals",
-      "merge_whitelist_teams",
-      "merge_whitelist_usernames",
-      "priority",
-      "protected_file_patterns",
-      "push_whitelist_deploy_keys",
-      "push_whitelist_teams",
-      "push_whitelist_usernames",
-      "require_signed_commits",
-      "required_approvals",
-      "rule_name",
-      "status_check_contexts",
-      "unprotected_file_patterns",
-      "updated_at"
-    ),
-    "Reference" -> Set("object", "ref", "url"),
-    "GitObject" -> Set("sha", "type", "url"),
-    "AnnotatedTag" -> Set("message", "object", "sha", "tag", "tagger", "url", "verification"),
-    "AnnotatedTagObject" -> Set("sha", "type", "url"),
-    "GitBlobResponse" -> Set("content", "encoding", "lfs_oid", "lfs_size", "sha", "size", "url"),
-    "ContentsResponse" -> Set(
-      "_links",
-      "content",
-      "download_url",
-      "encoding",
-      "git_url",
-      "html_url",
-      "last_author_date",
-      "last_commit_message",
-      "last_commit_sha",
-      "last_committer_date",
-      "lfs_oid",
-      "lfs_size",
-      "name",
-      "path",
-      "sha",
-      "size",
-      "submodule_git_url",
-      "target",
-      "type",
-      "url"
-    ),
-    "FileLinksResponse" -> Set("git", "html", "self")
-  )
+  /** The field names each schema declares in `plugin-redoc-2.yaml`.
+    *
+    * Wire field names used to live in three places: the vendored spec, the
+    * `@jsonField` annotations on the models, and a hand-typed copy of the spec
+    * in this file. The test compared the second copy against the third and
+    * never against the first, so two copies that were wrong in the same way —
+    * or a Gitea release that moved on — passed green.
+    *
+    * Reading the spec removes the third copy. Scoped to the `definitions:`
+    * block on purpose: `Attachment` is declared both there and again under
+    * `responses:`, and an unscoped search finds the wrong one.
+    */
+  private lazy val swaggerDefinitionFields: Map[String, Set[String]] =
+    val lines = Files.readString(swaggerPath(), StandardCharsets.UTF_8).linesIterator.toVector
+    val start = lines.indexWhere(_ == "definitions:")
+    val end =
+      lines.indexWhere(line => line.nonEmpty && !line.head.isWhitespace, start + 1) match
+        case -1 => lines.length
+        case index => index
+
+    definitionsIn(lines.slice(start + 1, end))
+
+  private def definitionsIn(block: Vector[String]): Map[String, Set[String]] =
+    // Indentation is the whole grammar here: a definition name sits at two
+    // spaces, `properties:` at four, and each field name at six.
+    val definitionStarts =
+      block.indices.filter(index => indentation(block(index)) == 2 && block(index).trim.endsWith(":"))
+
+    definitionStarts.map { index =>
+      val name = block(index).trim.dropRight(1)
+      val body = block.drop(index + 1).takeWhile(line => line.isBlank || indentation(line) >= 4)
+      name -> fieldNamesIn(body)
+    }.toMap
+
+  private def fieldNamesIn(definitionBody: Vector[String]): Set[String] =
+    definitionBody
+      .dropWhile(line => indentation(line) != 4 || line.trim != "properties:")
+      .drop(1)
+      .takeWhile(line => line.isBlank || indentation(line) >= 6)
+      .filter(line => indentation(line) == 6 && line.trim.endsWith(":"))
+      .map(_.trim.dropRight(1))
+      .toSet
+
+  private def indentation(line: String): Int =
+    line.takeWhile(_ == ' ').length
+
+  /** Finds the vendored spec by walking up from the working directory, the
+    * same way `GiteaEndpointAuditSpec` does, so the suite runs from any module.
+    */
+  private def swaggerPath(): Path =
+    Iterator
+      .iterate(Paths.get("").toAbsolutePath)(_.getParent)
+      .takeWhile(_ != null)
+      .map(_.resolve("plugin-redoc-2.yaml"))
+      .find(Files.isRegularFile(_))
+      .getOrElse(Paths.get("plugin-redoc-2.yaml").toAbsolutePath)
 
   private val schemaFieldChecklist = List(
     SchemaFieldChecklist(
@@ -415,20 +387,25 @@ object CoreModelsSpec extends ZIOSpecDefault:
   def spec =
     suite("Core models")(
       test("records Swagger field checklist for schema-traced response models") {
-        val checklistByDefinition =
-          schemaFieldChecklist.map(entry => entry.swaggerDefinition -> entry).toMap
+        // Every definition the checklist claims to trace must exist in the
+        // vendored spec, and the checklist must account for every field that
+        // definition declares. Read from the spec rather than from a copy of
+        // it, so a Gitea release that adds a field fails here instead of
+        // passing unnoticed.
         val missingDefinitions =
-          schemaChecklistSwaggerFields.keySet
-            .diff(checklistByDefinition.keySet)
-            .toList
+          schemaFieldChecklist
+            .map(_.swaggerDefinition)
+            .filterNot(swaggerDefinitionFields.contains)
             .sorted
-            .map(definition => s"$definition checklist entry is missing")
+            .map(definition => s"$definition is not declared in plugin-redoc-2.yaml")
         val missingChecklistFields =
-          schemaChecklistSwaggerFields.toList.flatMap { case (definition, expectedFields) =>
-            checklistByDefinition.get(definition).toList.flatMap { checklist =>
-              val missing = expectedFields.diff(checklist.jsonFields)
+          schemaFieldChecklist.flatMap { checklist =>
+            swaggerDefinitionFields.get(checklist.swaggerDefinition).toList.flatMap { declaredFields =>
+              val missing = declaredFields.diff(checklist.jsonFields)
 
-              Option.when(missing.nonEmpty)(s"$definition checklist missing ${missing.toList.sorted.mkString(", ")}")
+              Option.when(missing.nonEmpty)(
+                s"${checklist.swaggerDefinition} checklist missing ${missing.toList.sorted.mkString(", ")}"
+              )
             }
           }
         val missingEncodedFields =


### PR DESCRIPTION
## What this does

gitea4s is a Scala 3 client library for the Gitea API — an HTTP client that
turns Gitea's REST endpoints into typed Scala methods. This branch is the result
of a review of the whole library against a set of software-design rule sets
(Clean Code, Refactoring, Clean Architecture and nine others), followed by the
work that review justified.

It does two kinds of thing:

1. **Removes duplication and dead weight** without changing what the library
   does — mostly in `GiteaRequests`, which builds every HTTP request.
2. **Bounds five failure modes** where the library could hang, retry something
   it should not, or accept input it should reject.

There are ten commits, one per logical change, and each explains itself. Nothing
here removes or changes a published method signature.

## Why

The review produced 90 raw findings. Those were deduplicated to 24 and each was
then handed to a separate reviewer whose instructions were to *refute* it. 14
survived; 10 were thrown out as wrong, already handled, or not worth the churn.
This branch implements the survivors.

The findings worth knowing about, in the order a reader will care:

**Nothing checked that requests went to the right URL.** The library keeps a
catalog of 130 endpoints (`GiteaEndpoint`) mirroring the vendored OpenAPI
contract, and separately builds each real request URL from a list of path
segments. The test suite compared the catalog against the contract and the
request's *query parameters* against expectations — but never the request's
*path* against anything. A one-character typo (`"relases"` for `"releases"`)
passed all 130 audits. I confirmed this by introducing that exact typo first.

**130 lines of dead code with a doc comment asserting it was live.**
`GiteaEndpoints.all` had zero references anywhere, while its own comment said
"the audit suite folds over this list and checks each entry against the OpenAPI
contract". It did not. Rather than delete the list, this makes the comment true.

**A stalled connection was retried into a much longer stall.** The executor caps
one attempt at five minutes, because `GiteaConfig.timeout` reaches the JDK as
`HttpRequest.timeout` and stops applying the moment response headers arrive — so
a server that sends `200 OK` and then dribbles the body forever is exactly what
that cap exists for. But an exhausted cap was classified as a retryable
transport failure, so with the default `maxRetries = 3` a five-minute stall held
the caller for twenty minutes, across three extra attempts re-running the
condition least likely to have cleared.

**Two paths had no stall cap at all.** Streaming downloads (`GiteaDownloads`)
bypass the executor entirely — so the path meant for the *largest* bodies was
the one that could hang forever. And the OkHttp backend never set OkHttp's
`callTimeout`, whose default is "no limit"; its class documentation claimed the
opposite in so many words.

**The error-body size cap was trivially defeated.** `GiteaResponseMapper` caps
the response body kept on an error at 8 KiB, so one failed request cannot put a
multi-megabyte payload in a log line. The `message` field, lifted out of that
same untrusted body four lines below the cap, was uncapped. `{"message": "<4
MB>"}` walked straight past it.

**Credentials were only trimmed at the ends.** A CR or LF in the *middle* of a
token survived into the `Authorization` header, then failed as an untyped JDK
exception that quotes the credential back — after being retried three times. On
a backend that does not validate header values, that is header injection.

**Two test suites were checking one hand-maintained copy against another.**
`CoreModelsSpec` had an 86-line hand-typed transcription of the OpenAPI schema
and compared the models against *that*, never against the actual spec file
sitting in the repository.

## How it works

**`client/src/.../http/GiteaRequests.scala`** (2121 → 1983 lines). Three facts
were restated once per endpoint instead of once:

- The sttp tail (`.response(...).readTimeout(...).headers(...)` plus the retry
  flag) appeared verbatim in all nine verb helpers — `postJson` and `putJson`
  were byte-identical apart from `.post(` vs `.put(`. A new private `jsonCall`
  applies it once. The verb stays a compile-checked sttp call rather than
  becoming a runtime argument.
- `Some("page" -> ...), Some("limit" -> ...)` was re-inlined in ten query
  builders while `pageQuery` sat unused beside them. The copies had already
  drifted (nine put the pair last, one put it first). All ten now call
  `pageQuery`, each keeping its position so the query string is byte-identical.
- `paginatedUsers` was fixed to `Page[User]` though nothing in it depended on
  the type, so nine builders repeated the same six lines with a different type
  argument. It becomes `paginated[A]`.

**`client/test/.../GiteaEndpointAuditSpec.scala`**: adds a path-shape check
comparing the built URI against the endpoint's path template (literal segments
only — a `{template}` segment holds an arbitrary caller value), a verb check,
and two catalog-wide tests that fold over `GiteaEndpoints.all` and cross-check
it against the constants found by reflection.

**`client/src/.../internal/GiteaRequestExecutor.scala`**: the attempt timeout
now raises a distinct `AttemptBudgetExhausted`, matched ahead of the general
transport case in `retryDelay` and not retried. It extends `TimeoutException`,
so callers matching on the type see no change and sttp's own timeouts stay
retryable. `totalTimeout` is renamed `attemptTimeout` — it never bounded the
total, being applied inside the retry loop, and the error message said it did.
Separately, `send` passed a literal `null` down the default path; a small
`AttemptRecorder` with a shared no-op replaces it, so the default path still
allocates nothing.

**`backend-zio/.../GiteaDownloads.scala`**: `ZStream#timeoutFail` bounds each
*pull*, so the budget measures the gap between chunks — a slow multi-gigabyte
archive is never cut off, only a server that has stopped sending.

**`backend-okhttp/.../OkHttpGiteaBackend.scala`**: sets `callTimeout` from the
executor's attempt budget (past that point the caller's fiber has given up, so
ending the call costs nothing; `config.timeout` would kill a legitimately slow
archive). A borrowed client is only given one if the caller left it at 0.

**`client/src/.../GiteaConfig.scala`**: a shared `headerSafe` check rejects
control characters in the five settings that become header content. Existing
error types are reused, so no new public type appears. The error names the
setting, never the value.

**`core/test/.../CoreModelsSpec.scala`**: reads the schemas out of
`plugin-redoc-2.yaml`, scoped to the `definitions:` block — `Attachment` is
declared twice in that file and an unscoped search finds the wrong one.

### Rejected alternatives

- A maximal `call(config, endpoint, method, path, query, json, accept, decode)`
  funnel, proposed by two reviewers: it makes the verb a runtime argument and
  loses the compile-checked `.post`/`.put`, for a tail `jsonCall` already
  deduplicates.
- Deriving the request path from `endpoint.path`, or making `method` an enum:
  breaks a published case class and a 131-constant surface to close a gap two
  test edits close.
- A real end-to-end deadline across retries, or config fields for the timeouts:
  a second clock needs its interaction with the first explained at every read
  site, and the config fields would break the 1.0.0 case class to duplicate
  `ZIO.timeout`.
- A `PageWindow(page, pageSize)` parameter object: renames a two-line prelude at
  25 sites without removing it.

## How to test it

```bash
./mill __.compile __.test compatibility.check
```

All green from a clean build (`./mill clean` first if you want to be sure).
`compatibility.check` is the important one: it diffs the published API against
`api-snapshot/`. `core.txt` and `client.txt` are byte-identical. `backend-zio`
and `backend-okhttp` gain entries, all additions — the existing
`ZioGiteaDownloads(config, backend)` constructor is unchanged, so code compiled
against it keeps working.

Every new guard was checked to actually fail without its fix, because a test
that cannot fail is worse than no test:

```bash
# The path check. Introduce a typo, watch it caught:
sed -i '311s/"releases"/"relases"/' client/src/io/worxbend/gitea4s/http/GiteaRequests.scala
./mill client.test.testOnly io.worxbend.gitea4s.http.GiteaEndpointAuditSpec
# repoListReleases: request path segment actual=relases expected=releases
git checkout client/src/io/worxbend/gitea4s/http/GiteaRequests.scala

# The schema reader. Drop a field from a checklist:
# -> "Attachment checklist missing uuid"

# The read timeout. Delete `.readTimeout(config.timeout)` from `jsonCall`:
# -> "every verb carries the configured read timeout" fails, alone.

# The retry guard. Delete the AttemptBudgetExhausted case from `retryDelay`:
# -> "an exhausted budget is surfaced, not retried" fails on attempts == 1.

# The download guard. Delete the `.timeoutFail(...)`:
# -> backend-zio.test produces no result at all within 120s. That is the bug.
```

To reproduce the original error-message problem: return
`{"message": "<100 KiB>"}` with a 422 and read `GiteaError.message` — before
this branch it is 100 KiB while `body` is dutifully clipped to 8 KiB.

## Notes for reviewers

**Two things I got wrong along the way, both caught before merge, both worth
knowing because they are the kind of thing that hides in a green test run:**

1. The first version of the retry test asserted on `attempts` from the telemetry
   event. That counter only advances when a response *arrives*, and in a stall
   none ever does — so it read 1 whether the stall was retried or not, and the
   test passed with the fix reverted. It now counts calls at the backend.

2. The first version of the download test forked the stream and nudged a
   `TestClock`. That races the forked fiber: it passed in isolation and **hung
   `./mill __.test` for over thirty minutes** when the fiber had not yet reached
   the sleep. It now uses a short budget against a live clock, matching how
   `GiteaRequestExecutorSpec` already tests the equivalent path. This is why
   `ZioGiteaDownloads` gained a package-private factory taking the budget — the
   published constructor is untouched.

**Behaviour changes worth a second opinion**, none of which move a signature:

- `GiteaError.message` is now capped at 8 KiB.
- A stalled request fails after one budget instead of four.
- A config whose `user-agent` or token contains a control character now fails at
  parse time rather than on first request. This is the one change that can
  reject a configuration that previously worked. `GiteaConfig.withToken` and
  `Auth.Token(...)` are public and bypass parsing, so they stay unvalidated —
  this hardens the two parsing entry points, not every route to a `GiteaConfig`.

**Known trade-off.** `CoreModelsSpec` now scrapes YAML by indentation, so a
reformat of the vendored spec will break that suite. It fails loudly and locally
when that happens, which I judged better than a check that silently compares two
hand-maintained copies of the same thing. Happy to revisit if you disagree.

**Deliberately left out of scope**, each its own change if wanted: extending the
path audit past the 55 registered requests to all 130 (additive, reviewable in
small steps); deprecating the public `GiteaRequest.withJsonBody`; and tuning
OkHttp's `maxRequestsPerHost`, which was a symptom of the missing call timeout
rather than a cause.

**`AGENTS.md` is committed here** (first commit). It was untracked, while
`CLAUDE.md` consists of little more than `@AGENTS.md` and describes it as the
shared file all three named tools read. Anyone cloning the repo got a broken
import. Shout if it was untracked on purpose.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Rejects credentials and header values containing unsafe control characters.
  - Prevents sensitive credential details from appearing in validation errors.
  - Limits server-provided error messages to a safe maximum length.

- **Bug Fixes**
  - Improves request timeout handling and prevents stalled downloads from hanging indefinitely.
  - Applies timeout limits consistently across requests and streaming downloads.
  - Preserves configured retry behavior while avoiding retries after timeout exhaustion.

- **Documentation**
  - Added guidance covering validation, retries, and timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->