### PR TITLE
Second pass: enum drift, HOCON duration, observer hang, and two release-safety holes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,15 @@ name: CI
 
 on:
   push:
+    branches: [master]
   pull_request:
   workflow_dispatch:
+
+# Without this, a push to a branch that has an open PR runs the whole matrix
+# twice, and superseded runs keep burning runners after a follow-up push.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 # This workflow only compiles and tests; it never writes to the repository.
 permissions:
@@ -35,8 +42,7 @@ jobs:
         with:
           path: |
             ~/.cache/coursier
-            ~/.ivy2/cache
-            ~/.mill
+            ~/.cache/mill
           key: ${{ runner.os }}-java-${{ matrix.java }}-scala-${{ matrix.scala }}-${{ hashFiles('build.mill', 'mill') }}
 
       - name: Verify build configuration

--- a/.github/workflows/publish-central.yml
+++ b/.github/workflows/publish-central.yml
@@ -24,6 +24,10 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          # Tags are needed by the version check below, and the default shallow
+          # checkout fetches none.
+          fetch-depth: 0
 
       - name: Set up Java
         uses: actions/setup-java@v4
@@ -42,10 +46,35 @@ jobs:
 
       - name: Verify release version
         run: |
+          set -euo pipefail
+
           if grep -q 'val library = ".*-SNAPSHOT"' build.mill; then
             echo "Refusing to publish a SNAPSHOT version to Maven Central." >&2
             exit 1
           fi
+
+          # This workflow is dispatched by hand against whatever ref the
+          # operator picked, and a Maven Central release can never be taken
+          # back. The only check was the SNAPSHOT one above, so a mistyped ref
+          # could permanently publish an arbitrary commit under whatever
+          # version build.mill happened to carry.
+          #
+          # Require the commit to be the one that was actually released: it has
+          # to carry the matching v<version> tag.
+          library="$(sed -n 's/^[[:space:]]*val library = "\(.*\)"$/\1/p' build.mill)"
+
+          if [ -z "$library" ]; then
+            echo "Could not read 'val library' from build.mill." >&2
+            exit 1
+          fi
+
+          if ! git tag --points-at HEAD | grep -qx "v$library"; then
+            echo "Refusing to publish: HEAD is not tagged 'v$library'." >&2
+            echo "Tags on HEAD: $(git tag --points-at HEAD | tr '\n' ' ')" >&2
+            exit 1
+          fi
+
+          echo "Publishing $library from tag v$library"
 
       - name: Validate build
         run: |

--- a/.github/workflows/publish-central.yml
+++ b/.github/workflows/publish-central.yml
@@ -15,6 +15,12 @@ on:
 permissions:
   contents: read
 
+# Maven Central publication is immutable, so a cancelled mid-upload run is worse
+# than a queued one.
+concurrency:
+  group: publish-central
+  cancel-in-progress: false
+
 jobs:
   publish:
     name: Publish Maven Central artifacts
@@ -25,6 +31,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           # Tags are needed by the version check below, and the default shallow
           # checkout fetches none.
           fetch-depth: 0
@@ -40,8 +47,7 @@ jobs:
         with:
           path: |
             ~/.cache/coursier
-            ~/.ivy2/cache
-            ~/.mill
+            ~/.cache/mill
           key: ${{ runner.os }}-publish-central-${{ hashFiles('build.mill', 'mill') }}
 
       - name: Verify release version
@@ -96,11 +102,16 @@ jobs:
           SHOULD_RELEASE: ${{ inputs.release }}
           REF_NAME: ${{ github.ref_name }}
         run: |
+          # Credentials and signing arguments are deliberately NOT passed as
+          # flags. Process arguments are readable through /proc/<pid>/cmdline
+          # and show up in `ps`, so `--password` and a `--gpgArgs` string
+          # carrying `--passphrase=` put both secrets in the process table for
+          # the lifetime of the publish. Mill already reads all four from the
+          # MILL_SONATYPE_* and MILL_PGP_* variables in the `env:` block above,
+          # and the gpg arguments removed here were character-for-character
+          # Mill's own default. Do not reinstate them.
           ./mill mill.javalib.SonatypeCentralPublishModule/publishAll \
             --publishArtifacts __.publishArtifacts \
-            --username "$MILL_SONATYPE_USERNAME" \
-            --password "$MILL_SONATYPE_PASSWORD" \
-            --gpgArgs "--passphrase=$MILL_PGP_PASSPHRASE,--no-tty,--pinentry-mode,loopback,--batch,--yes,--armor,--detach-sign" \
             --readTimeout 36000 \
             --awaitTimeout 36000 \
             --connectTimeout 36000 \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,12 @@ permissions:
   contents: write # create the GitHub Release and upload jar assets
   packages: write # publish Maven artifacts to GitHub Packages
 
+# A release must never be cancelled part-way through uploading artifacts: half
+# the jars published is worse than none. Queue instead.
+concurrency:
+  group: release-${{ inputs.tag || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Publish jars to GitHub Packages and Releases
@@ -31,6 +37,13 @@ jobs:
         with:
           ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0
+          # This job's GITHUB_TOKEN carries contents:write and packages:write.
+          # Checkout otherwise leaves it in .git/config as an http.extraheader
+          # for the whole job — including while `./mill __.test` and
+          # `./mill examples.run` execute code from the ref being released.
+          # Nothing here needs the git credential: uploads authenticate
+          # explicitly through `curl -u` and `gh` with GH_TOKEN from `env:`.
+          persist-credentials: false
 
       - name: Set up Java
         uses: actions/setup-java@v4
@@ -43,8 +56,7 @@ jobs:
         with:
           path: |
             ~/.cache/coursier
-            ~/.ivy2/cache
-            ~/.mill
+            ~/.cache/mill
           key: ${{ runner.os }}-release-${{ hashFiles('build.mill', 'mill') }}
 
       - name: Resolve release tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,11 +67,34 @@ jobs:
           echo "Releasing $TAG"
 
       - name: Verify release version
+        env:
+          TAG: ${{ steps.meta.outputs.tag }}
         run: |
+          set -euo pipefail
+
           if grep -q 'val library = ".*-SNAPSHOT"' build.mill; then
             echo "Refusing to publish a SNAPSHOT version." >&2
             exit 1
           fi
+
+          # The tag names the release; `Versions.library` names the artifacts.
+          # Nothing compared them, so tagging v2.0.0 while build.mill still said
+          # 1.0.0 published 1.0.0 jars, attached them to a Release called
+          # v2.0.0, and reported success. Anyone resolving 2.0.0 afterwards got
+          # a version that was never published.
+          library="$(sed -n 's/^[[:space:]]*val library = "\(.*\)"$/\1/p' build.mill)"
+
+          if [ -z "$library" ]; then
+            echo "Could not read 'val library' from build.mill." >&2
+            exit 1
+          fi
+
+          if [ "$TAG" != "v$library" ]; then
+            echo "Tag '$TAG' does not match build.mill version '$library' (expected 'v$library')." >&2
+            exit 1
+          fi
+
+          echo "Publishing $library as $TAG"
 
       - name: Validate build
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,19 @@ compiled against it keeps working.
 
 ### Security
 
+- **Publishing workflows verify the version they are shipping.** `release.yml`
+  validated only the *shape* of a `v*` tag, so tagging `v2.0.0` while
+  `build.mill` still said `1.0.0` published 1.0.0 jars under a v2.0.0 release
+  and reported success. `publish-central.yml` — whose output is immutable —
+  could be dispatched against any ref and would publish it. Both now require the
+  tag and `Versions.library` to agree, and Central additionally requires the
+  commit to carry that tag.
+
+- **Secrets no longer travel in process arguments.** The Central publish passed
+  `--password` and a `--gpgArgs` string containing `--passphrase=`, both
+  readable via `/proc/<pid>/cmdline` and `ps`. Mill already reads all four
+  credentials from the environment; the flags were redundant as well as leaky.
+
 - **Control characters in credentials are rejected at parse time.** `fromEnv`
   and the HOCON readers trimmed surrounding whitespace but accepted a CR or LF
   *inside* `token`, `username`, `password`, `user-agent` or `otp`. Such a value
@@ -100,6 +113,27 @@ compiled against it keeps working.
   follow redirects; configs without one are unaffected.
 
 ### Fixed
+
+- **An unknown enum value no longer discards a whole page.** Every enum decoder
+  rejected any string it did not list, and a page decodes as one `Chunk`, so a
+  single unrecognised value failed the entire page and then the stream above it.
+  Since Gitea adds enum members between minor versions, a server upgrade could
+  start emptying a client's collections. Read positions now decode an unknown
+  value as `None`; write positions stay strict.
+
+- **HOCON `timeout = 30` meant 30 milliseconds.** Typesafe Config reads a
+  unitless number in duration position as milliseconds, so that parsed cleanly
+  and gave every request a 30ms budget, while the identical `GITEA_TIMEOUT=30`
+  was rejected with a helpful message. The unitless form is now rejected in both
+  readers. Settings spelled the environment's way (`maxRetries` for
+  `max-retries`) were silently read by nobody, and are now rejected with the
+  intended spelling; unrelated keys are still accepted.
+
+- **A hanging observer could withhold a completed result.** `catchAllCause`
+  covered an observer that fails, not one that never finishes — and the
+  documented escape hatch, offering to a `Queue`, is exactly what suspends on a
+  full queue. Callbacks are now abandoned after one second and their event
+  dropped.
 
 - **A stalled request is no longer retried into a much longer stall.** The
   five-minute end-to-end cap is applied per attempt, and an exhausted cap was
@@ -193,6 +227,17 @@ compiled against it keeps working.
   yourself if you were relying on it arriving transitively.
 
 ### Added
+
+- **`GiteaError.message`** on the sealed trait, so an error can be logged or
+  displayed without a thirteen-case match. The four cases that carried no
+  message field derive one. Additive: no constructor, `apply`, `copy` or
+  `unapply` changes.
+
+- **`GITEA_USER_AGENT` and `GITEA_OTP`**, so the environment reader accepts the
+  same settings as the HOCON reader. Both go through the same
+  control-character guard as the credentials. Note that `X-Gitea-OTP` is
+  time-based, so a fixed value suits a short-lived command rather than a
+  long-running process.
 
 - **`GiteaConfig` builder methods.** `withBaseUrl`, `withAuth`, `withTimeout`,
   `withPageSize`, `withUserAgent`, `withOtp`, `withMaxRetries` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,16 @@ with `NoSuchMethodError` at runtime. Recompiling is enough; no source edit is
 needed. Nothing was removed: `Auth`'s per-case `toString` moved onto the `Auth`
 parent class, which callers still reach through normal virtual dispatch.
 
-The API snapshot gained entries in `backend-zio` and `backend-okhttp` only;
-`core` and `client` are byte-identical. Every entry is an addition — the
-existing `ZioGiteaDownloads(config, backend)` constructor is unchanged, so code
-compiled against it keeps working.
+All four modules gained `api-snapshot/` entries, and every entry is an addition:
+`GiteaError.message` and the lenient enum decoders in `core`, two environment
+variable names in `client`, and test seams in the two backends. Nothing was
+re-typed and no signature moved, so code compiled against `1.0.0` keeps
+compiling — the recompile note above is about the widened case classes, not
+these.
+
+One entry was removed: `GiteaRequest$StringImpl`, a `private final class` that
+no Scala code outside its own file could ever name. It appeared in the snapshot
+only because that tool reads bytecode, where Scala's `private` is not enforced.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,9 +74,11 @@ compiled against it keeps working.
 - **Server-supplied retry delays are bounded.** A 429 carrying
   `x-ratelimit-reset` was believed unconditionally. A proxy that reports the
   reset in milliseconds sends a value that is a valid epoch *second* tens of
-  thousands of years out, which parked the fiber indefinitely. Retry instants
-  more than 24 hours ahead are now ignored, and the wait is capped at 60
-  seconds regardless, so a remote header can no longer override your timeout.
+  thousands of years out, which parked the fiber indefinitely. The wait is now
+  capped at 60 seconds, so a remote header can no longer override your timeout.
+  The instant itself is still reported on `GiteaError.RateLimited.resetAt`
+  exactly as the server sent it — deciding how long to wait is the client's
+  job, and a decoder has no clock to judge "how far ahead" with.
 - **JSON responses have a size ceiling.** sttp's default is unlimited, and
   `readTimeout` does not help because a body that arrives steadily never trips
   it. JSON and diff/patch responses are now capped at 32 MiB. The buffered

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ lives in `README.md`; the roadmap lives in `PLAN.md`.
 ```bash
 ./mill __.compile            # compile all modules
 ./mill __.test               # hermetic unit tests
-./mill it.test               # opt-in live integration tests (see below)
+GITEA_IT=1 ./mill it.test    # opt-in live integration tests (see below)
 ./mill examples.run          # hermetic by default
 ./mill compatibility.check   # public-API binary-compat guard
 ./mill __.docJar __.sourceJar __.publishArtifacts
@@ -92,11 +92,21 @@ mapper tests, and pagination tests:
 Live tests run only when their required environment variables are all non-empty;
 otherwise ZIO Test reports them as ignored and makes no network calls.
 
+The whole suite additionally requires `GITEA_IT` to be set. Without it every
+test is ignored, including on a machine that happens to have `GITEA_URL` and
+`GITEA_TOKEN` exported — which is what keeps `./mill __.test` (where `it.test`
+also lives) genuinely hermetic for a maintainer.
+
 Baseline (authenticated user + repo stream):
 
 ```bash
-GITEA_URL=https://gitea.example GITEA_TOKEN=... ./mill it.test
+GITEA_IT=1 GITEA_URL=https://gitea.example GITEA_TOKEN=... ./mill it.test
 ```
+
+Basic auth works too: `GITEA_USERNAME` + `GITEA_PASSWORD` in place of
+`GITEA_TOKEN`. Both paths are gated equally — previously only the token was
+checked, so a username/password run reported every test ignored and a green
+`SUCCESS` having made no network calls at all.
 
 Additional probes are each gated on their own variables (all must be non-empty,
 in addition to `GITEA_URL`/`GITEA_TOKEN`/`GITEA_OWNER`/`GITEA_REPO`):
@@ -116,7 +126,7 @@ in addition to `GITEA_URL`/`GITEA_TOKEN`/`GITEA_OWNER`/`GITEA_REPO`):
 To prove hermetic skipping (no network), unset the full live-variable set:
 
 ```bash
-env -u GITEA_URL -u GITEA_TOKEN -u GITEA_USERNAME -u GITEA_PASSWORD \
+env -u GITEA_IT -u GITEA_URL -u GITEA_TOKEN -u GITEA_USERNAME -u GITEA_PASSWORD \
     -u GITEA_OWNER -u GITEA_REPO -u GITEA_REF -u GITEA_ANNOTATED_TAG_SHA \
     -u GITEA_CONTENTS_FILEPATH -u GITEA_CONTENTS_REF -u GITEA_ARCHIVE \
     -u GITEA_RAW_FILEPATH -u GITEA_RAW_REF \
@@ -135,13 +145,14 @@ outside standard manifests:
 
 - `//| mill-version` in `build.mill`
 - `DEFAULT_MILL_VERSION` in the checked-in `mill` launcher
-- `Versions.scala`, `Versions.zio`, `Versions.zioJson`, `Versions.zioConfig`,
+- `Versions.scala`, `Versions.zio`, `Versions.zioJson`, `Versions.typesafeConfig`,
   and `Versions.sttp` in `build.mill`
 
 Dependency PRs should run the full release-readiness validation:
 
 ```bash
-./mill __.compile __.test it.test examples.run compatibility.check
+./mill __.compile __.test examples.run compatibility.check
+GITEA_IT=1 ./mill it.test    # only with a live server configured
 ./mill __.docJar __.sourceJar __.publishArtifacts
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,7 @@ in addition to `GITEA_URL`/`GITEA_TOKEN`/`GITEA_OWNER`/`GITEA_REPO`):
 | Slash-containing Git ref routing | `GITEA_REF` (e.g. `heads/main`) | Validates single-segment ref encoding. |
 | Annotated tag lookup | `GITEA_ANNOTATED_TAG_SHA` | Must be an annotated tag object SHA, not a tag-list entry. |
 | Repository contents filepath | `GITEA_CONTENTS_FILEPATH` (e.g. `docs/readme.md`); optional `GITEA_CONTENTS_REF` | |
+| Raw file download | `GITEA_RAW_FILEPATH`; optional `GITEA_RAW_REF` | Exercises the buffered byte-response path. |
 | Repository archive | `GITEA_ARCHIVE` (e.g. `main.zip`); optional comma-separated `GITEA_ARCHIVE_PATHS` | |
 | Release detail / asset list | `GITEA_RELEASE_ID` | Asset-list also asserts membership when `GITEA_RELEASE_ASSET_ID` is set. |
 | Single release asset | `GITEA_RELEASE_ID` + `GITEA_RELEASE_ASSET_ID` | |
@@ -118,6 +119,7 @@ To prove hermetic skipping (no network), unset the full live-variable set:
 env -u GITEA_URL -u GITEA_TOKEN -u GITEA_USERNAME -u GITEA_PASSWORD \
     -u GITEA_OWNER -u GITEA_REPO -u GITEA_REF -u GITEA_ANNOTATED_TAG_SHA \
     -u GITEA_CONTENTS_FILEPATH -u GITEA_CONTENTS_REF -u GITEA_ARCHIVE \
+    -u GITEA_RAW_FILEPATH -u GITEA_RAW_REF \
     -u GITEA_ARCHIVE_PATHS -u GITEA_RELEASE_ID -u GITEA_RELEASE_TAG \
     -u GITEA_LATEST_RELEASE_TAG -u GITEA_RELEASE_ASSET_ID \
     ./mill --no-server it.test

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,11 @@ pipeline {
 
     stage('Integration Tests') {
       steps {
-        sh './mill it.test'
+        // GITEA_IT is the suite's explicit opt-in; without it every live test
+        // is ignored, which is what keeps `./mill __.test` hermetic elsewhere.
+        withEnv(['GITEA_IT=1']) {
+          sh './mill it.test'
+        }
       }
     }
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,13 @@ default), so asking for more per page than the server allows is not an error —
 you simply get the server's maximum, and the stream keeps paging until the
 collection is exhausted.
 
+These streams are page-offset scans of a live collection, not snapshots. Each
+page is a separate request, so if items are inserted or deleted while a crawl
+is running, an item can be emitted twice or missed entirely — everything after
+the insertion point shifts by one. Resuming with `page = Some(n)` inherits the
+same hazard. If you need exactly-once handling, key on the item's `id` rather
+than assuming the stream delivers each item once.
+
 ## Namespaces
 
 The client is organized into resource namespaces; every call goes through one:
@@ -305,10 +312,15 @@ client.users.me.foldZIO(
 
 ## Observability
 
-Set a `GiteaObserver` to hook logging, metrics, or tracing into every request.
-It runs after each call completes (with the endpoint, total duration, and
-outcome), cannot change the result, and a faulty observer can never break a
-request. The default is a no-op with zero overhead.
+Set a `GiteaObserver` to hook logging, metrics, or tracing into every
+`GiteaClient` request. It runs after each call completes (with the endpoint,
+total duration, and outcome), cannot change the result, and a faulty observer
+can never break a request. The default is a no-op with zero overhead.
+
+`backend-zio`'s streaming downloads are the exception: `GiteaDownloads` sends
+directly against the backend rather than through the executor, so it emits no
+observer events. Those streams are bounded by their own stall budget rather
+than the executor's attempt budget, and are never retried.
 
 ```scala
 import io.worxbend.gitea4s.observability.GiteaObserver
@@ -336,9 +348,14 @@ never duplicate a write.
 
 On a `429` the client honours `Retry-After` — both the delay-seconds and
 HTTP-date forms — and falls back to `x-ratelimit-reset`. Those values are
-server-controlled, so they are bounded: an instant more than 24 hours out is
-ignored entirely, and the wait is capped at 60 seconds, so a bad or hostile
-header cannot silently override your timeout.
+server-controlled, so the **wait** they produce is capped at 60 seconds: a bad
+or hostile header cannot silently override your timeout.
+
+The instant itself is reported to you unfiltered. `GiteaError.RateLimited.resetAt`
+is whatever the server said, including a value implausibly far in the future —
+a proxy that reports the reset in milliseconds sends a number that is a valid
+epoch *second* thousands of years out. Treat it as untrusted input if you
+display it or act on it; only the client's own sleep is bounded.
 
 Each attempt is also capped end to end (five minutes). `GiteaConfig.timeout`
 alone cannot do this: it reaches the JDK as `HttpRequest.timeout`, which stops

--- a/README.md
+++ b/README.md
@@ -133,7 +133,15 @@ both `GITEA_USERNAME` and `GITEA_PASSWORD`):
 ```text
 GITEA_URL  GITEA_TOKEN  GITEA_USERNAME  GITEA_PASSWORD
 GITEA_PAGE_SIZE  GITEA_TIMEOUT  GITEA_MAX_RETRIES
+GITEA_USER_AGENT  GITEA_OTP
 ```
+
+The environment and HOCON readers accept the same settings. `GITEA_OTP` is
+included for that symmetry rather than as a way to do two-factor auth:
+`X-Gitea-OTP` carries a *time-based* one-time password, so a value fixed in the
+environment (or in a config file, which has always been possible) goes stale
+within about thirty seconds. It suits a short-lived command, not a long-running
+process.
 
 `GITEA_URL` is the **server root**, not the API root: use
 `https://gitea.example`, not `https://gitea.example/api/v1`. The `/api/v1`

--- a/README.md
+++ b/README.md
@@ -153,6 +153,17 @@ gitea4s {
 }
 ```
 
+Durations must carry a unit. Typesafe Config reads a bare number in duration
+position as *milliseconds*, so `timeout = 30` would mean 30ms rather than the 30
+seconds almost anyone writing it intends; it is rejected with the same message
+the environment reader gives. `timeout = 30s` and `timeout = 2 minutes` both
+work.
+
+Settings spelled the way the environment spells them are also rejected rather
+than ignored — `maxRetries` in a `gitea4s { }` block is a different key from
+`max-retries`, and used to be read by nobody. Keys unrelated to gitea4s are left
+alone, so an application can keep its own settings alongside these.
+
 Every setting can also be changed on an existing config:
 
 ```scala

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -125,9 +125,17 @@ Note that GitHub Packages requires consumers to authenticate even for public
 packages.
 
 **JitPack** builds on demand from `jitpack.yml`, which installs Temurin 21 via
-SDKMAN (the default JitPack image is Java 8) and runs `./mill __.publishM2Local`.
-No workflow or secret is involved; the first request for a tag triggers the
-build. Bump the pinned Temurin version in `jitpack.yml` if SDKMAN delists it.
+SDKMAN (the default JitPack image is Java 8), then compiles, tests, and runs
+`./mill __.publishM2Local`. No workflow or secret is involved; the first request
+for a tag triggers the build. Bump the pinned Temurin version in `jitpack.yml`
+if SDKMAN delists it.
+
+The test step matters here more than it looks: JitPack exists to serve
+pre-release commits, so it is the channel most likely to be asked for a broken
+one, and whatever it builds is what a consumer resolves. `compatibility.check`
+is deliberately *not* run there — it would fail every commit whose
+`api-snapshot/` baseline has not been regenerated yet, which is exactly the
+traffic this channel is for.
 
 ## Compatibility Policy
 

--- a/api-snapshot/client.txt
+++ b/api-snapshot/client.txt
@@ -152,6 +152,8 @@ public final class io.worxbend.gitea4s.GiteaConfig$Env$ implements java.io.Seria
   public java.lang.String pageSize();
   public java.lang.String timeout();
   public java.lang.String maxRetries();
+  public java.lang.String userAgent();
+  public java.lang.String otp();
 }
 
 ## io.worxbend.gitea4s.GiteaConfig$Typesafe$
@@ -1388,17 +1390,6 @@ public final class io.worxbend.gitea4s.http.GiteaRequest$Impl<A, B> implements i
   public scala.util.Either<io.worxbend.gitea4s.error.GiteaError, A> decode(sttp.client4.Response<B>);
 }
 
-## io.worxbend.gitea4s.http.GiteaRequest$StringImpl
-public final class io.worxbend.gitea4s.http.GiteaRequest$StringImpl<A> implements io.worxbend.gitea4s.http.GiteaRequest<A> {
-  public io.worxbend.gitea4s.http.GiteaRequest$StringImpl(io.worxbend.gitea4s.http.GiteaEndpoint, sttp.client4.Request<java.lang.String>, scala.Function1<sttp.client4.Response<java.lang.String>, scala.util.Either<io.worxbend.gitea4s.error.GiteaError, A>>, boolean);
-  public io.worxbend.gitea4s.http.GiteaRequest<A> copy(boolean);
-  public boolean copy$default$1();
-  public io.worxbend.gitea4s.http.GiteaEndpoint endpoint();
-  public sttp.client4.Request<java.lang.String> request();
-  public boolean retryable();
-  public scala.util.Either<io.worxbend.gitea4s.error.GiteaError, A> decode(sttp.client4.Response<java.lang.String>);
-}
-
 ## io.worxbend.gitea4s.http.GiteaRequests
 public final class io.worxbend.gitea4s.http.GiteaRequests {
   public static io.worxbend.gitea4s.http.GiteaRequest<zio.Chunk<io.worxbend.gitea4s.model.Label>> addIssueLabels(io.worxbend.gitea4s.GiteaConfig, java.lang.String, java.lang.String, long, io.worxbend.gitea4s.model.IssueLabelsOption);
@@ -1798,8 +1789,8 @@ public final class io.worxbend.gitea4s.http.GiteaResponseMapper$ implements java
   public scala.util.Either<io.worxbend.gitea4s.error.GiteaError, io.worxbend.gitea4s.model.Page<io.worxbend.gitea4s.model.User>> decodeUserSearchPage(sttp.client4.Response<java.lang.String>, int, int);
   public io.worxbend.gitea4s.error.GiteaError toError(sttp.client4.Response<java.lang.String>);
   public scala.Option<java.time.Instant> retryAt(sttp.client4.Response<java.lang.String>);
-  public static final java.lang.Object io$worxbend$gitea4s$http$GiteaResponseMapper$UserSearchResults$$$_$_$_$$anonfun$3();
-  public static final java.lang.Object io$worxbend$gitea4s$http$GiteaResponseMapper$UserSearchResults$$$_$_$_$$anonfun$4();
+  public static final java.lang.Object io$worxbend$gitea4s$http$GiteaResponseMapper$UserSearchResults$$$_$_$_$$anonfun$1();
+  public static final java.lang.Object io$worxbend$gitea4s$http$GiteaResponseMapper$UserSearchResults$$$_$_$_$$anonfun$2();
 }
 
 ## io.worxbend.gitea4s.http.GiteaResponseMapper$UserSearchResults

--- a/api-snapshot/core.txt
+++ b/api-snapshot/core.txt
@@ -1622,6 +1622,7 @@ public abstract class io.worxbend.gitea4s.model.CommitStatusState implements sca
   public static io.worxbend.gitea4s.model.CommitStatusState fromOrdinal(int);
   public static scala.util.Either<java.lang.String, io.worxbend.gitea4s.model.CommitStatusState> fromString(java.lang.String);
   public static zio.json.JsonCodec<io.worxbend.gitea4s.model.CommitStatusState> given_JsonCodec_CommitStatusState();
+  public static zio.json.JsonDecoder<scala.Option<io.worxbend.gitea4s.model.CommitStatusState>> given_JsonDecoder_Option();
   public static io.worxbend.gitea4s.model.CommitStatusState valueOf(java.lang.String);
   public static io.worxbend.gitea4s.model.CommitStatusState[] values();
 }
@@ -1640,6 +1641,7 @@ public final class io.worxbend.gitea4s.model.CommitStatusState$ implements scala
   public io.worxbend.gitea4s.model.CommitStatusState fromOrdinal(int);
   public scala.util.Either<java.lang.String, io.worxbend.gitea4s.model.CommitStatusState> fromString(java.lang.String);
   public final zio.json.JsonCodec<io.worxbend.gitea4s.model.CommitStatusState> given_JsonCodec_CommitStatusState();
+  public final zio.json.JsonDecoder<scala.Option<io.worxbend.gitea4s.model.CommitStatusState>> given_JsonDecoder_Option();
   public int ordinal(io.worxbend.gitea4s.model.CommitStatusState);
   public int ordinal(java.lang.Object);
 }
@@ -3041,6 +3043,7 @@ public abstract class io.worxbend.gitea4s.model.IssueState implements scala.refl
   public static io.worxbend.gitea4s.model.IssueState fromOrdinal(int);
   public static scala.util.Either<java.lang.String, io.worxbend.gitea4s.model.IssueState> fromString(java.lang.String);
   public static zio.json.JsonCodec<io.worxbend.gitea4s.model.IssueState> given_JsonCodec_IssueState();
+  public static zio.json.JsonDecoder<scala.Option<io.worxbend.gitea4s.model.IssueState>> given_JsonDecoder_Option();
   public static io.worxbend.gitea4s.model.IssueState valueOf(java.lang.String);
   public static io.worxbend.gitea4s.model.IssueState[] values();
 }
@@ -3055,8 +3058,17 @@ public final class io.worxbend.gitea4s.model.IssueState$ implements scala.derivi
   public io.worxbend.gitea4s.model.IssueState fromOrdinal(int);
   public scala.util.Either<java.lang.String, io.worxbend.gitea4s.model.IssueState> fromString(java.lang.String);
   public final zio.json.JsonCodec<io.worxbend.gitea4s.model.IssueState> given_JsonCodec_IssueState();
+  public final zio.json.JsonDecoder<scala.Option<io.worxbend.gitea4s.model.IssueState>> given_JsonDecoder_Option();
   public int ordinal(io.worxbend.gitea4s.model.IssueState);
   public int ordinal(java.lang.Object);
+}
+
+## io.worxbend.gitea4s.model.JsonValueLookup
+public final class io.worxbend.gitea4s.model.JsonValueLookup<A> {
+  public io.worxbend.gitea4s.model.JsonValueLookup(java.lang.Object, java.lang.String, scala.Function1<A, java.lang.String>);
+  public scala.util.Either<java.lang.String, A> fromString(java.lang.String);
+  public zio.json.JsonCodec<A> codec();
+  public zio.json.JsonDecoder<scala.Option<A>> lenientOptionDecoder();
 }
 
 ## io.worxbend.gitea4s.model.Label
@@ -3205,6 +3217,7 @@ public abstract class io.worxbend.gitea4s.model.MergePullRequestMethod implement
   public static io.worxbend.gitea4s.model.MergePullRequestMethod fromOrdinal(int);
   public static scala.util.Either<java.lang.String, io.worxbend.gitea4s.model.MergePullRequestMethod> fromString(java.lang.String);
   public static zio.json.JsonCodec<io.worxbend.gitea4s.model.MergePullRequestMethod> given_JsonCodec_MergePullRequestMethod();
+  public static zio.json.JsonDecoder<scala.Option<io.worxbend.gitea4s.model.MergePullRequestMethod>> given_JsonDecoder_Option();
   public static io.worxbend.gitea4s.model.MergePullRequestMethod valueOf(java.lang.String);
   public static io.worxbend.gitea4s.model.MergePullRequestMethod[] values();
 }
@@ -3223,6 +3236,7 @@ public final class io.worxbend.gitea4s.model.MergePullRequestMethod$ implements 
   public io.worxbend.gitea4s.model.MergePullRequestMethod fromOrdinal(int);
   public scala.util.Either<java.lang.String, io.worxbend.gitea4s.model.MergePullRequestMethod> fromString(java.lang.String);
   public final zio.json.JsonCodec<io.worxbend.gitea4s.model.MergePullRequestMethod> given_JsonCodec_MergePullRequestMethod();
+  public final zio.json.JsonDecoder<scala.Option<io.worxbend.gitea4s.model.MergePullRequestMethod>> given_JsonDecoder_Option();
   public int ordinal(io.worxbend.gitea4s.model.MergePullRequestMethod);
   public int ordinal(java.lang.Object);
 }
@@ -3566,6 +3580,7 @@ public abstract class io.worxbend.gitea4s.model.NotificationSubjectState impleme
   public static io.worxbend.gitea4s.model.NotificationSubjectState fromOrdinal(int);
   public static scala.util.Either<java.lang.String, io.worxbend.gitea4s.model.NotificationSubjectState> fromString(java.lang.String);
   public static zio.json.JsonCodec<io.worxbend.gitea4s.model.NotificationSubjectState> given_JsonCodec_NotificationSubjectState();
+  public static zio.json.JsonDecoder<scala.Option<io.worxbend.gitea4s.model.NotificationSubjectState>> given_JsonDecoder_Option();
   public static io.worxbend.gitea4s.model.NotificationSubjectState valueOf(java.lang.String);
   public static io.worxbend.gitea4s.model.NotificationSubjectState[] values();
 }
@@ -3581,6 +3596,7 @@ public final class io.worxbend.gitea4s.model.NotificationSubjectState$ implement
   public io.worxbend.gitea4s.model.NotificationSubjectState fromOrdinal(int);
   public scala.util.Either<java.lang.String, io.worxbend.gitea4s.model.NotificationSubjectState> fromString(java.lang.String);
   public final zio.json.JsonCodec<io.worxbend.gitea4s.model.NotificationSubjectState> given_JsonCodec_NotificationSubjectState();
+  public final zio.json.JsonDecoder<scala.Option<io.worxbend.gitea4s.model.NotificationSubjectState>> given_JsonDecoder_Option();
   public int ordinal(io.worxbend.gitea4s.model.NotificationSubjectState);
   public int ordinal(java.lang.Object);
 }
@@ -3597,6 +3613,7 @@ public abstract class io.worxbend.gitea4s.model.NotificationSubjectType implemen
   public static io.worxbend.gitea4s.model.NotificationSubjectType fromOrdinal(int);
   public static scala.util.Either<java.lang.String, io.worxbend.gitea4s.model.NotificationSubjectType> fromString(java.lang.String);
   public static zio.json.JsonCodec<io.worxbend.gitea4s.model.NotificationSubjectType> given_JsonCodec_NotificationSubjectType();
+  public static zio.json.JsonDecoder<scala.Option<io.worxbend.gitea4s.model.NotificationSubjectType>> given_JsonDecoder_Option();
   public static io.worxbend.gitea4s.model.NotificationSubjectType valueOf(java.lang.String);
   public static io.worxbend.gitea4s.model.NotificationSubjectType[] values();
 }
@@ -3613,6 +3630,7 @@ public final class io.worxbend.gitea4s.model.NotificationSubjectType$ implements
   public io.worxbend.gitea4s.model.NotificationSubjectType fromOrdinal(int);
   public scala.util.Either<java.lang.String, io.worxbend.gitea4s.model.NotificationSubjectType> fromString(java.lang.String);
   public final zio.json.JsonCodec<io.worxbend.gitea4s.model.NotificationSubjectType> given_JsonCodec_NotificationSubjectType();
+  public final zio.json.JsonDecoder<scala.Option<io.worxbend.gitea4s.model.NotificationSubjectType>> given_JsonDecoder_Option();
   public int ordinal(io.worxbend.gitea4s.model.NotificationSubjectType);
   public int ordinal(java.lang.Object);
 }
@@ -3693,6 +3711,7 @@ public abstract class io.worxbend.gitea4s.model.ObjectFormatName implements scal
   public static io.worxbend.gitea4s.model.ObjectFormatName fromOrdinal(int);
   public static scala.util.Either<java.lang.String, io.worxbend.gitea4s.model.ObjectFormatName> fromString(java.lang.String);
   public static zio.json.JsonCodec<io.worxbend.gitea4s.model.ObjectFormatName> given_JsonCodec_ObjectFormatName();
+  public static zio.json.JsonDecoder<scala.Option<io.worxbend.gitea4s.model.ObjectFormatName>> given_JsonDecoder_Option();
   public static io.worxbend.gitea4s.model.ObjectFormatName valueOf(java.lang.String);
   public static io.worxbend.gitea4s.model.ObjectFormatName[] values();
 }
@@ -3707,6 +3726,7 @@ public final class io.worxbend.gitea4s.model.ObjectFormatName$ implements scala.
   public io.worxbend.gitea4s.model.ObjectFormatName fromOrdinal(int);
   public scala.util.Either<java.lang.String, io.worxbend.gitea4s.model.ObjectFormatName> fromString(java.lang.String);
   public final zio.json.JsonCodec<io.worxbend.gitea4s.model.ObjectFormatName> given_JsonCodec_ObjectFormatName();
+  public final zio.json.JsonDecoder<scala.Option<io.worxbend.gitea4s.model.ObjectFormatName>> given_JsonDecoder_Option();
   public int ordinal(io.worxbend.gitea4s.model.ObjectFormatName);
   public int ordinal(java.lang.Object);
 }
@@ -4588,6 +4608,7 @@ public abstract class io.worxbend.gitea4s.model.PullReviewState implements scala
   public static io.worxbend.gitea4s.model.PullReviewState fromOrdinal(int);
   public static scala.util.Either<java.lang.String, io.worxbend.gitea4s.model.PullReviewState> fromString(java.lang.String);
   public static zio.json.JsonCodec<io.worxbend.gitea4s.model.PullReviewState> given_JsonCodec_PullReviewState();
+  public static zio.json.JsonDecoder<scala.Option<io.worxbend.gitea4s.model.PullReviewState>> given_JsonDecoder_Option();
   public static io.worxbend.gitea4s.model.PullReviewState valueOf(java.lang.String);
   public static io.worxbend.gitea4s.model.PullReviewState[] values();
 }
@@ -4605,6 +4626,7 @@ public final class io.worxbend.gitea4s.model.PullReviewState$ implements scala.d
   public io.worxbend.gitea4s.model.PullReviewState fromOrdinal(int);
   public scala.util.Either<java.lang.String, io.worxbend.gitea4s.model.PullReviewState> fromString(java.lang.String);
   public final zio.json.JsonCodec<io.worxbend.gitea4s.model.PullReviewState> given_JsonCodec_PullReviewState();
+  public final zio.json.JsonDecoder<scala.Option<io.worxbend.gitea4s.model.PullReviewState>> given_JsonDecoder_Option();
   public int ordinal(io.worxbend.gitea4s.model.PullReviewState);
   public int ordinal(java.lang.Object);
 }
@@ -5500,6 +5522,7 @@ public abstract class io.worxbend.gitea4s.model.TeamPermission implements scala.
   public static io.worxbend.gitea4s.model.TeamPermission fromOrdinal(int);
   public static scala.util.Either<java.lang.String, io.worxbend.gitea4s.model.TeamPermission> fromString(java.lang.String);
   public static zio.json.JsonCodec<io.worxbend.gitea4s.model.TeamPermission> given_JsonCodec_TeamPermission();
+  public static zio.json.JsonDecoder<scala.Option<io.worxbend.gitea4s.model.TeamPermission>> given_JsonDecoder_Option();
   public static io.worxbend.gitea4s.model.TeamPermission valueOf(java.lang.String);
   public static io.worxbend.gitea4s.model.TeamPermission[] values();
 }
@@ -5517,6 +5540,7 @@ public final class io.worxbend.gitea4s.model.TeamPermission$ implements scala.de
   public io.worxbend.gitea4s.model.TeamPermission fromOrdinal(int);
   public scala.util.Either<java.lang.String, io.worxbend.gitea4s.model.TeamPermission> fromString(java.lang.String);
   public final zio.json.JsonCodec<io.worxbend.gitea4s.model.TeamPermission> given_JsonCodec_TeamPermission();
+  public final zio.json.JsonDecoder<scala.Option<io.worxbend.gitea4s.model.TeamPermission>> given_JsonDecoder_Option();
   public int ordinal(io.worxbend.gitea4s.model.TeamPermission);
   public int ordinal(java.lang.Object);
 }

--- a/api-snapshot/core.txt
+++ b/api-snapshot/core.txt
@@ -4,6 +4,7 @@
 
 ## io.worxbend.gitea4s.error.GiteaError
 public interface io.worxbend.gitea4s.error.GiteaError extends scala.Product,java.io.Serializable {
+  public abstract java.lang.String message();
   public static int ordinal(io.worxbend.gitea4s.error.GiteaError);
 }
 
@@ -26,6 +27,8 @@ public final class io.worxbend.gitea4s.error.GiteaError$ implements scala.derivi
   public static {};
   public int ordinal(io.worxbend.gitea4s.error.GiteaError);
   public int ordinal(java.lang.Object);
+  public static final java.lang.String io$worxbend$gitea4s$error$GiteaError$RateLimited$$_$message$$anonfun$1();
+  public static final java.lang.String io$worxbend$gitea4s$error$GiteaError$RateLimited$$_$message$$anonfun$2(java.time.Instant);
 }
 
 ## io.worxbend.gitea4s.error.GiteaError$BadRequest
@@ -339,6 +342,7 @@ public final class io.worxbend.gitea4s.error.GiteaError$RateLimited implements i
   public java.lang.String productElementName(int);
   public scala.Option<java.time.Instant> resetAt();
   public java.lang.String body();
+  public java.lang.String message();
   public io.worxbend.gitea4s.error.GiteaError$RateLimited copy(scala.Option<java.time.Instant>, java.lang.String);
   public scala.Option<java.time.Instant> copy$default$1();
   public java.lang.String copy$default$2();
@@ -376,6 +380,7 @@ public final class io.worxbend.gitea4s.error.GiteaError$ServerError implements i
   public java.lang.String productElementName(int);
   public int status();
   public java.lang.String body();
+  public java.lang.String message();
   public io.worxbend.gitea4s.error.GiteaError$ServerError copy(int, java.lang.String);
   public int copy$default$1();
   public java.lang.String copy$default$2();
@@ -412,6 +417,7 @@ public final class io.worxbend.gitea4s.error.GiteaError$TransportError implement
   public java.lang.Object productElement(int);
   public java.lang.String productElementName(int);
   public java.lang.Throwable cause();
+  public java.lang.String message();
   public io.worxbend.gitea4s.error.GiteaError$TransportError copy(java.lang.Throwable);
   public java.lang.Throwable copy$default$1();
   public java.lang.Throwable _1();

--- a/backend-zio/src/io/worxbend/gitea4s/backend/zio/GiteaDownloads.scala
+++ b/backend-zio/src/io/worxbend/gitea4s/backend/zio/GiteaDownloads.scala
@@ -30,6 +30,11 @@ import java.util.concurrent.TimeoutException
   * These streams are not retried: a partially consumed body cannot be safely
   * replayed. Use the buffered `GiteaClient` methods where retry matters.
   *
+  * They also emit no `GiteaObserver` events. The request is sent straight at
+  * the backend rather than through `GiteaRequestExecutor`, which is what owns
+  * the observer — so a configured observer sees every `GiteaClient` call and
+  * none of these.
+  *
   * A stalled download fails rather than hanging. The budget measures the gap
   * between chunks, not the total download time, so an archive that takes an
   * hour to arrive is never penalised as long as it keeps arriving — see

--- a/build.mill
+++ b/build.mill
@@ -15,8 +15,11 @@ object Versions:
   val zio = "2.1.26"
   // renovate: datasource=maven depName=dev.zio:zio-json_3 versioning=maven
   val zioJson = "0.9.2"
-  // renovate: datasource=maven depName=dev.zio:zio-config_3 versioning=maven
-  val zioConfig = "4.0.7"
+  // The HOCON reader `GiteaConfig.fromTypesafeConfig` uses, and the type its
+  // public signature names. Declared directly rather than inherited from
+  // zio-config: a library whose API mentions a type must depend on it.
+  // renovate: datasource=maven depName=com.typesafe:config versioning=maven
+  val typesafeConfig = "1.4.6"
   // renovate: datasource=maven depName=com.softwaremill.sttp.client4:core_3 versioning=maven
   val sttp = "4.0.25"
 
@@ -101,8 +104,7 @@ object client extends PublishableGitea4sModule:
 
   def mvnDeps = Seq(
     mvn"com.softwaremill.sttp.client4::core:${Versions.sttp}",
-    mvn"dev.zio::zio-config:${Versions.zioConfig}",
-    mvn"dev.zio::zio-config-typesafe:${Versions.zioConfig}"
+    mvn"com.typesafe:config:${Versions.typesafeConfig}"
   )
 
 object `backend-zio` extends PublishableGitea4sModule:

--- a/client/src/io/worxbend/gitea4s/GiteaConfig.scala
+++ b/client/src/io/worxbend/gitea4s/GiteaConfig.scala
@@ -1,6 +1,6 @@
 package io.worxbend.gitea4s
 
-import com.typesafe.config.{Config, ConfigException, ConfigFactory}
+import com.typesafe.config.{Config, ConfigException, ConfigFactory, ConfigValueType}
 import io.worxbend.gitea4s.model.Auth
 import io.worxbend.gitea4s.observability.GiteaObserver
 import sttp.model.Uri
@@ -9,6 +9,7 @@ import zio.{ZIO, ZLayer}
 import java.nio.charset.StandardCharsets
 import java.util.Base64
 import scala.concurrent.duration.*
+import scala.jdk.CollectionConverters.*
 import scala.jdk.DurationConverters.*
 import scala.util.Try
 
@@ -336,9 +337,56 @@ object GiteaConfig:
 
   private def typesafeSection(config: Config, path: String): Either[GiteaConfigError, Config] =
     try
-      if config.hasPath(path) then Right(config.getConfig(path))
+      if config.hasPath(path) then
+        val section = config.getConfig(path)
+        misspelledKey(section, path).toLeft(section)
       else Left(GiteaConfigError.MissingRequiredConfig(path))
     catch case error: ConfigException => Left(GiteaConfigError.InvalidConfig(path, safeMessage(error)))
+
+  /** The nine settings this reader understands. */
+  private val knownTypesafeKeys: List[String] =
+    List(
+      Typesafe.url,
+      Typesafe.token,
+      Typesafe.username,
+      Typesafe.password,
+      Typesafe.pageSize,
+      Typesafe.timeout,
+      Typesafe.userAgent,
+      Typesafe.otp,
+      Typesafe.maxRetries
+    )
+
+  /** Catches a setting spelled the way the environment spells it.
+    *
+    * Typesafe Config does no normalisation, so `maxRetries` in a `gitea4s { }`
+    * block is simply a different key from `max-retries` and was read by nobody —
+    * the config loaded cleanly and the setting did nothing. The environment
+    * names actively invite that mistake: someone who knows `GITEA_MAX_RETRIES`
+    * writes `maxRetries` or `max_retries` far more readily than `max-retries`.
+    *
+    * Only *near misses* are rejected: a key that collapses onto a known setting
+    * once case and separators are ignored, but is not spelled like it.
+    * Genuinely unrelated keys are left alone, because applications legitimately
+    * keep their own settings beside these, and failing on those would turn a
+    * silent typo into a broken startup for configurations that work today.
+    */
+  private def misspelledKey(section: Config, path: String): Option[GiteaConfigError] =
+    def normalise(key: String): String = key.toLowerCase.filter(_.isLetterOrDigit)
+
+    val knownByNormalised = knownTypesafeKeys.map(key => normalise(key) -> key).toMap
+
+    section
+      .root()
+      .keySet()
+      .asScala
+      .toList
+      .sorted
+      .flatMap(key => knownByNormalised.get(normalise(key)).filterNot(_ == key).map(key -> _))
+      .headOption
+      .map { (written, known) =>
+        GiteaConfigError.InvalidConfig(qualified(path, written), s"is not a known setting; did you mean '$known'?")
+      }
 
   private def requiredBaseUrlFromConfig(config: Config, path: String): Either[GiteaConfigError, Uri] =
     optionalStringFromConfig(config, path, Typesafe.url).flatMap {
@@ -393,12 +441,41 @@ object GiteaConfig:
       defaultValue: FiniteDuration
   ): Either[GiteaConfigError, FiniteDuration] =
     if !config.hasPath(localPath) then Right(defaultValue)
+    else if isUnitlessDuration(config, localPath) then
+      Left(GiteaConfigError.InvalidConfig(path, durationRequirement))
     else
       try
         config.getDuration(localPath).toScala match
           case duration: FiniteDuration if duration > Duration.Zero => Right(duration)
-          case _ => Left(GiteaConfigError.InvalidConfig(path, "must be a positive finite duration such as 30s"))
-      catch case _: ConfigException => Left(GiteaConfigError.InvalidConfig(path, "must be a positive finite duration such as 30s"))
+          case _ => Left(GiteaConfigError.InvalidConfig(path, durationRequirement))
+      catch case _: ConfigException => Left(GiteaConfigError.InvalidConfig(path, durationRequirement))
+
+  /** Whether a HOCON duration was written without a unit.
+    *
+    * Typesafe Config reads a bare number in duration position as
+    * *milliseconds*. So `timeout = 30` parsed happily as 30ms, cleared the
+    * positive check, and gave every request a 30-millisecond budget — while the
+    * identical `GITEA_TIMEOUT=30` was rejected by the environment reader with a
+    * message telling the user to write `30s`. The same text meant two very
+    * different things depending on where it was written, and the wrong one was
+    * silent: every call then failed as a transport timeout, three retries deep,
+    * with nothing pointing at the config file.
+    *
+    * A quoted `"30"` is read the same way, so strings are checked too — a
+    * duration string always ends in a unit letter.
+    *
+    * Only the unitless case is rejected here. `getDuration` still handles
+    * everything else, because HOCON accepts spellings Scala's own `Duration`
+    * parser does not (`30 m`, `1 day`), and reading them with a shared grammar
+    * would break configuration files that already work.
+    */
+  private def isUnitlessDuration(config: Config, localPath: String): Boolean =
+    config.getValue(localPath).valueType match
+      case ConfigValueType.NUMBER => true
+      case ConfigValueType.STRING => !config.getString(localPath).trim.lastOption.exists(_.isLetter)
+      case _ => false
+
+  private val durationRequirement: String = "must be a positive finite duration such as 30s"
 
   private def optionalStringFromConfig(
       config: Config,

--- a/client/src/io/worxbend/gitea4s/GiteaConfig.scala
+++ b/client/src/io/worxbend/gitea4s/GiteaConfig.scala
@@ -126,6 +126,17 @@ object GiteaConfig:
     val pageSize: String = "GITEA_PAGE_SIZE"
     val timeout: String = "GITEA_TIMEOUT"
     val maxRetries: String = "GITEA_MAX_RETRIES"
+    val userAgent: String = "GITEA_USER_AGENT"
+
+    /** The `X-Gitea-OTP` header value.
+      *
+      * Present for parity with the HOCON reader, which has always accepted it.
+      * Be aware of what it can and cannot do: `X-Gitea-OTP` carries a
+      * *time-based* one-time password, so a value fixed in the environment is
+      * stale within about thirty seconds. It suits a short-lived command, not a
+      * long-running process.
+      */
+    val otp: String = "GITEA_OTP"
 
   object Typesafe:
     val root: String = "gitea4s"
@@ -190,11 +201,21 @@ object GiteaConfig:
       pageSize <- positiveIntFromEnv(env, Env.pageSize, defaultPageSize)
       timeout <- finiteDurationFromEnv(env, Env.timeout, defaultTimeout)
       maxRetries <- nonNegativeIntFromEnv(env, Env.maxRetries, defaultMaxRetries)
-    yield default(baseUrl, auth).copy(
-      timeout = timeout,
-      pageSize = pageSize,
-      maxRetries = maxRetries
-    )
+      // Through the same guard as the credentials: both become header content,
+      // and reading them with a plain `nonBlank` would reopen the injection
+      // hole that guard exists to close.
+      userAgent <- headerSafe(nonBlank(env, Env.userAgent), GiteaConfigError.InvalidEnv(Env.userAgent, _))
+      otp <- headerSafe(nonBlank(env, Env.otp), GiteaConfigError.InvalidEnv(Env.otp, _))
+    yield
+      val baseConfig = default(baseUrl, auth)
+      baseConfig.copy(
+        timeout = timeout,
+        pageSize = pageSize,
+        maxRetries = maxRetries,
+        // Same fallback as the HOCON reader, so both sources default alike.
+        userAgent = userAgent.orElse(baseConfig.userAgent),
+        otp = otp
+      )
 
   def fromTypesafeConfig(config: Config, path: String = Typesafe.root): Either[GiteaConfigError, GiteaConfig] =
     for

--- a/client/src/io/worxbend/gitea4s/GiteaConfig.scala
+++ b/client/src/io/worxbend/gitea4s/GiteaConfig.scala
@@ -13,6 +13,20 @@ import scala.jdk.CollectionConverters.*
 import scala.jdk.DurationConverters.*
 import scala.util.Try
 
+/** The content types this client negotiates.
+  *
+  * These three values were previously loose `String` constants matched against
+  * a `String` parameter, and the call sites had drifted into four spellings of
+  * them: `MediaType.ApplicationJson.toString`, `MediaType.TextPlain.toString`,
+  * two bare `"application/octet-stream"` literals, and the constants
+  * themselves. A closed type makes a mismatch a compile error rather than a
+  * request that quietly asks for the wrong thing.
+  */
+private[gitea4s] enum Accept(val headerValue: String):
+  case Json extends Accept("application/json")
+  case OctetStream extends Accept("application/octet-stream")
+  case TextPlain extends Accept("text/plain")
+
 final case class GiteaConfig(
     baseUrl: Uri,
     auth: Auth,
@@ -56,21 +70,21 @@ final case class GiteaConfig(
     * `username:password` string and its backing byte array on the heap every
     * time, multiplying the copies a heap dump or a swap file could recover.
     *
-    * The three `Accept` values this library actually sends are memoised; any
-    * other value is still handled, just without the memoisation, so adding an
-    * endpoint that negotiates a new content type cannot silently be served the
-    * wrong `Accept` header.
+    * `Accept` is a closed type, so this match is total and every value the
+    * library can ask for is memoised. It used to take a `String` and fall
+    * through to an unmemoised build for anything unrecognised, which meant a
+    * new content type — or a typo in an existing one — silently lost the
+    * memoisation instead of failing to compile.
     */
-  private[gitea4s] def headersAccepting(accept: String): Map[String, String] =
+  private[gitea4s] def headersAccepting(accept: Accept): Map[String, String] =
     accept match
-      case GiteaConfig.applicationJson => jsonHeaders
-      case GiteaConfig.octetStream => octetStreamHeaders
-      case GiteaConfig.textPlain => textPlainHeaders
-      case other => buildHeaders(other)
+      case Accept.Json => jsonHeaders
+      case Accept.OctetStream => octetStreamHeaders
+      case Accept.TextPlain => textPlainHeaders
 
-  private[gitea4s] lazy val jsonHeaders: Map[String, String] = buildHeaders(GiteaConfig.applicationJson)
-  private[gitea4s] lazy val octetStreamHeaders: Map[String, String] = buildHeaders(GiteaConfig.octetStream)
-  private[gitea4s] lazy val textPlainHeaders: Map[String, String] = buildHeaders(GiteaConfig.textPlain)
+  private[gitea4s] lazy val jsonHeaders: Map[String, String] = buildHeaders(Accept.Json.headerValue)
+  private[gitea4s] lazy val octetStreamHeaders: Map[String, String] = buildHeaders(Accept.OctetStream.headerValue)
+  private[gitea4s] lazy val textPlainHeaders: Map[String, String] = buildHeaders(Accept.TextPlain.headerValue)
 
   private def buildHeaders(accept: String): Map[String, String] =
     List(
@@ -149,10 +163,6 @@ object GiteaConfig:
     val userAgent: String = "user-agent"
     val otp: String = "otp"
     val maxRetries: String = "max-retries"
-
-  private[gitea4s] val applicationJson: String = "application/json"
-  private[gitea4s] val octetStream: String = "application/octet-stream"
-  private[gitea4s] val textPlain: String = "text/plain"
 
   val defaultTimeout: FiniteDuration = 30.seconds
   val defaultPageSize: Int = 50

--- a/client/src/io/worxbend/gitea4s/api/ReposApi.scala
+++ b/client/src/io/worxbend/gitea4s/api/ReposApi.scala
@@ -135,6 +135,14 @@ trait ReposApi:
 
   def newIssuePinsAllowed(owner: String, repo: String): IO[GiteaError, NewIssuePinsAllowed]
 
+  /** Every topic on the repository.
+    *
+    * The endpoint is paginated and this crawls it to exhaustion rather than
+    * returning a stream, because Gitea caps a repository at 25 topics — below
+    * the default page size, so in practice this is a single request. The other
+    * paginated reads on this trait return a `ZStream` precisely because their
+    * collections have no such bound.
+    */
   def topics(owner: String, repo: String): IO[GiteaError, Chunk[String]]
 
   def branches(owner: String, repo: String): ZStream[Any, GiteaError, Branch]

--- a/client/src/io/worxbend/gitea4s/http/GiteaRequest.scala
+++ b/client/src/io/worxbend/gitea4s/http/GiteaRequest.scala
@@ -23,7 +23,7 @@ object GiteaRequest:
       decode: Response[String] => Either[GiteaError, A],
       retryable: Boolean
   ): GiteaRequest[A] { type Body = String } =
-    new StringImpl(endpoint, request, decode, retryable)
+    new Impl[A, String](endpoint, request, decode, retryable)
 
   def withBody[A, B](
       endpoint: GiteaEndpoint,
@@ -45,15 +45,4 @@ object GiteaRequest:
     type Body = B
 
     def decode(response: Response[B]): Either[GiteaError, A] =
-      decodeResponse(response)
-
-  private final class StringImpl[A](
-      val endpoint: GiteaEndpoint,
-      val request: Request[String],
-      decodeResponse: Response[String] => Either[GiteaError, A],
-      val retryable: Boolean
-  ) extends GiteaRequest[A]:
-    type Body = String
-
-    def decode(response: Response[String]): Either[GiteaError, A] =
       decodeResponse(response)

--- a/client/src/io/worxbend/gitea4s/http/GiteaRequests.scala
+++ b/client/src/io/worxbend/gitea4s/http/GiteaRequests.scala
@@ -554,7 +554,7 @@ object GiteaRequests:
       GiteaResponseMapper.decodeJson[AnnotatedTag]
     )
 
-  def repoListAllGitRefs(config: GiteaConfig, owner: String, repo: String): GiteaRequest[zio.Chunk[Reference]] =
+  def repoListAllGitRefs(config: GiteaConfig, owner: String, repo: String): GiteaRequest[Chunk[Reference]] =
     get(
       config,
       GiteaEndpoints.repoListAllGitRefs,
@@ -568,7 +568,7 @@ object GiteaRequests:
       owner: String,
       repo: String,
       ref: String
-  ): GiteaRequest[zio.Chunk[Reference]] =
+  ): GiteaRequest[Chunk[Reference]] =
     get(
       config,
       GiteaEndpoints.repoListGitRefs,
@@ -582,7 +582,7 @@ object GiteaRequests:
       owner: String,
       repo: String,
       params: ContentsParams = ContentsParams.default
-  ): GiteaRequest[zio.Chunk[ContentsResponse]] =
+  ): GiteaRequest[Chunk[ContentsResponse]] =
     get(
       config,
       GiteaEndpoints.repoGetContentsList,
@@ -710,7 +710,7 @@ object GiteaRequests:
       GiteaResponseMapper.decodeJson[PullRequest]
     )
 
-  def pinnedPullRequests(config: GiteaConfig, owner: String, repo: String): GiteaRequest[zio.Chunk[PullRequest]] =
+  def pinnedPullRequests(config: GiteaConfig, owner: String, repo: String): GiteaRequest[Chunk[PullRequest]] =
     get(
       config,
       GiteaEndpoints.repoListPinnedPullRequests,
@@ -827,7 +827,7 @@ object GiteaRequests:
       repo: String,
       index: Long,
       body: PullReviewRequestOptions
-  ): GiteaRequest[zio.Chunk[PullReview]] =
+  ): GiteaRequest[Chunk[PullReview]] =
     postJson(
       config,
       GiteaEndpoints.repoCreatePullReviewRequests,
@@ -956,7 +956,7 @@ object GiteaRequests:
       repo: String,
       index: Long,
       id: Long
-  ): GiteaRequest[zio.Chunk[PullReviewComment]] =
+  ): GiteaRequest[Chunk[PullReviewComment]] =
     get(
       config,
       GiteaEndpoints.repoGetPullReviewComments,
@@ -1031,7 +1031,7 @@ object GiteaRequests:
       response => GiteaResponseMapper.decodePage[Issue](response, page, pageSize)
     )
 
-  def pinnedIssues(config: GiteaConfig, owner: String, repo: String): GiteaRequest[zio.Chunk[Issue]] =
+  def pinnedIssues(config: GiteaConfig, owner: String, repo: String): GiteaRequest[Chunk[Issue]] =
     get(
       config,
       GiteaEndpoints.repoListPinnedIssues,
@@ -1132,7 +1132,7 @@ object GiteaRequests:
       repo: String,
       index: Long,
       params: IssueCommentListParams = IssueCommentListParams.default
-  ): GiteaRequest[zio.Chunk[Comment]] =
+  ): GiteaRequest[Chunk[Comment]] =
     get(
       config,
       GiteaEndpoints.issueGetComments,
@@ -1195,7 +1195,7 @@ object GiteaRequests:
       owner: String,
       repo: String,
       id: Long
-  ): GiteaRequest[zio.Chunk[Reaction]] =
+  ): GiteaRequest[Chunk[Reaction]] =
     get(
       config,
       GiteaEndpoints.issueGetCommentReactions,
@@ -1302,7 +1302,7 @@ object GiteaRequests:
       GiteaResponseMapper.decodeJson[Issue]
     )
 
-  def issueLabels(config: GiteaConfig, owner: String, repo: String, index: Long): GiteaRequest[zio.Chunk[Label]] =
+  def issueLabels(config: GiteaConfig, owner: String, repo: String, index: Long): GiteaRequest[Chunk[Label]] =
     get(
       config,
       GiteaEndpoints.issueGetLabels,
@@ -1317,7 +1317,7 @@ object GiteaRequests:
       repo: String,
       index: Long,
       body: IssueLabelsOption
-  ): GiteaRequest[zio.Chunk[Label]] =
+  ): GiteaRequest[Chunk[Label]] =
     putJson(
       config,
       GiteaEndpoints.issueReplaceLabels,
@@ -1332,7 +1332,7 @@ object GiteaRequests:
       repo: String,
       index: Long,
       body: IssueLabelsOption
-  ): GiteaRequest[zio.Chunk[Label]] =
+  ): GiteaRequest[Chunk[Label]] =
     postJson(
       config,
       GiteaEndpoints.issueAddLabel,
@@ -1948,7 +1948,7 @@ object GiteaRequests:
       params.before.map(value => "before" -> value.toString),
     ).flatten ++ pageQuery(page, pageSize)
 
-  private def nonEmptyCsv(name: String, values: zio.Chunk[String]): Option[(String, String)] =
+  private def nonEmptyCsv(name: String, values: Chunk[String]): Option[(String, String)] =
     Option.when(values.nonEmpty)(name -> values.mkString(","))
 
   /** A plain paged GET: one whose only query parameters are `page` and `limit`.

--- a/client/src/io/worxbend/gitea4s/http/GiteaRequests.scala
+++ b/client/src/io/worxbend/gitea4s/http/GiteaRequests.scala
@@ -1,6 +1,6 @@
 package io.worxbend.gitea4s.http
 
-import io.worxbend.gitea4s.GiteaConfig
+import io.worxbend.gitea4s.{Accept, GiteaConfig}
 import io.worxbend.gitea4s.error.GiteaError
 import io.worxbend.gitea4s.model.{
   AddTimeOption,
@@ -124,29 +124,11 @@ object GiteaRequests:
 
   def organizationRepos(config: GiteaConfig, org: String, params: RepoListParams = RepoListParams.default)
       : GiteaRequest[Page[Repository]] =
-    val page = params.page.getOrElse(1)
-    val pageSize = params.limit.getOrElse(config.pageSize)
-
-    get(
-      config,
-      GiteaEndpoints.orgListRepos,
-      List("orgs", org, "repos"),
-      pageQuery(page, pageSize),
-      response => GiteaResponseMapper.decodePage[Repository](response, page, pageSize)
-    )
+    paginatedWindow[Repository](config, GiteaEndpoints.orgListRepos, List("orgs", org, "repos"), params.page, params.limit)
 
   def userRepos(config: GiteaConfig, username: String, params: RepoListParams = RepoListParams.default)
       : GiteaRequest[Page[Repository]] =
-    val page = params.page.getOrElse(1)
-    val pageSize = params.limit.getOrElse(config.pageSize)
-
-    get(
-      config,
-      GiteaEndpoints.userListRepos,
-      List("users", username, "repos"),
-      pageQuery(page, pageSize),
-      response => GiteaResponseMapper.decodePage[Repository](response, page, pageSize)
-    )
+    paginatedWindow[Repository](config, GiteaEndpoints.userListRepos, List("users", username, "repos"), params.page, params.limit)
 
   def repoTopics(config: GiteaConfig, owner: String, repo: String, page: Int = 1): GiteaRequest[Page[String]] =
     val pageSize = config.pageSize
@@ -224,7 +206,7 @@ object GiteaRequests:
       List("repos", owner, repo, "signing-key.gpg"),
       Nil,
       GiteaResponseMapper.decodeString,
-      accept = MediaType.TextPlain.toString
+      accept = Accept.TextPlain
     )
 
   def repoTag(config: GiteaConfig, owner: String, repo: String, tag: String): GiteaRequest[Tag] =
@@ -279,15 +261,13 @@ object GiteaRequests:
       repo: String,
       params: ReleaseListParams = ReleaseListParams.default
   ): GiteaRequest[Page[Release]] =
-    val page = params.page.getOrElse(1)
-    val pageSize = params.limit.getOrElse(config.pageSize)
-
-    get(
+    paginatedWindow[Release](
       config,
       GiteaEndpoints.repoListReleases,
       List("repos", owner, repo, "releases"),
-      releaseQuery(params, page, pageSize),
-      response => GiteaResponseMapper.decodePage[Release](response, page, pageSize)
+      params.page,
+      params.limit,
+      releaseQuery(params, _, _)
     )
 
   def repoReleases(config: GiteaConfig, owner: String, repo: String, page: Int): GiteaRequest[Page[Release]] =
@@ -422,15 +402,13 @@ object GiteaRequests:
       ref: String,
       params: CommitStatusListParams = CommitStatusListParams.default
   ): GiteaRequest[Page[CommitStatus]] =
-    val page = params.page.getOrElse(1)
-    val pageSize = params.limit.getOrElse(config.pageSize)
-
-    get(
+    paginatedWindow[CommitStatus](
       config,
       GiteaEndpoints.repoListStatusesByRef,
       List("repos", owner, repo, "commits", ref, "statuses"),
-      commitStatusQuery(params, page, pageSize),
-      response => GiteaResponseMapper.decodePage[CommitStatus](response, page, pageSize)
+      params.page,
+      params.limit,
+      commitStatusQuery(params, _, _)
     )
 
   def repoStatuses(
@@ -440,15 +418,13 @@ object GiteaRequests:
       sha: String,
       params: CommitStatusListParams = CommitStatusListParams.default
   ): GiteaRequest[Page[CommitStatus]] =
-    val page = params.page.getOrElse(1)
-    val pageSize = params.limit.getOrElse(config.pageSize)
-
-    get(
+    paginatedWindow[CommitStatus](
       config,
       GiteaEndpoints.repoListStatuses,
       List("repos", owner, repo, "statuses", sha),
-      commitStatusQuery(params, page, pageSize),
-      response => GiteaResponseMapper.decodePage[CommitStatus](response, page, pageSize)
+      params.page,
+      params.limit,
+      commitStatusQuery(params, _, _)
     )
 
   def createStatus(
@@ -503,7 +479,7 @@ object GiteaRequests:
       List("repos", owner, repo, "git", "commits", s"$sha.${diffType.pathValue}"),
       Nil,
       GiteaResponseMapper.decodeString,
-      accept = MediaType.TextPlain.toString
+      accept = Accept.TextPlain
     )
 
   def repoCommitNote(
@@ -685,15 +661,13 @@ object GiteaRequests:
       repo: String,
       params: PullRequestListParams = PullRequestListParams.default
   ): GiteaRequest[Page[PullRequest]] =
-    val page = params.page.getOrElse(1)
-    val pageSize = params.limit.getOrElse(config.pageSize)
-
-    get(
+    paginatedWindow[PullRequest](
       config,
       GiteaEndpoints.repoListPullRequests,
       List("repos", owner, repo, "pulls"),
-      pullRequestQuery(params, page, pageSize),
-      response => GiteaResponseMapper.decodePage[PullRequest](response, page, pageSize)
+      params.page,
+      params.limit,
+      pullRequestQuery(params, _, _)
     )
 
   def createPullRequest(
@@ -979,7 +953,7 @@ object GiteaRequests:
       List("repos", owner, repo, "pulls", s"$index.${diffType.pathValue}"),
       binary.map(value => List("binary" -> value.toString)).getOrElse(Nil),
       GiteaResponseMapper.decodeString,
-      accept = MediaType.TextPlain.toString
+      accept = Accept.TextPlain
     )
 
   def repoPullRequestFiles(
@@ -989,15 +963,13 @@ object GiteaRequests:
       index: Long,
       params: PullRequestFilesParams = PullRequestFilesParams.default
   ): GiteaRequest[Page[ChangedFile]] =
-    val page = params.page.getOrElse(1)
-    val pageSize = params.limit.getOrElse(config.pageSize)
-
-    get(
+    paginatedWindow[ChangedFile](
       config,
       GiteaEndpoints.repoGetPullRequestFiles,
       List("repos", owner, repo, "pulls", index.toString, "files"),
-      pullRequestFilesQuery(params, page, pageSize),
-      response => GiteaResponseMapper.decodePage[ChangedFile](response, page, pageSize)
+      params.page,
+      params.limit,
+      pullRequestFilesQuery(params, _, _)
     )
 
   def repoPullRequestCommits(
@@ -1007,28 +979,24 @@ object GiteaRequests:
       index: Long,
       params: PullRequestCommitsParams = PullRequestCommitsParams.default
   ): GiteaRequest[Page[Commit]] =
-    val page = params.page.getOrElse(1)
-    val pageSize = params.limit.getOrElse(config.pageSize)
-
-    get(
+    paginatedWindow[Commit](
       config,
       GiteaEndpoints.repoGetPullRequestCommits,
       List("repos", owner, repo, "pulls", index.toString, "commits"),
-      pullRequestCommitsQuery(params, page, pageSize),
-      response => GiteaResponseMapper.decodePage[Commit](response, page, pageSize)
+      params.page,
+      params.limit,
+      pullRequestCommitsQuery(params, _, _)
     )
 
   def issues(config: GiteaConfig, owner: String, repo: String, params: IssueListParams = IssueListParams.default)
       : GiteaRequest[Page[Issue]] =
-    val page = params.page.getOrElse(1)
-    val pageSize = params.limit.getOrElse(config.pageSize)
-
-    get(
+    paginatedWindow[Issue](
       config,
       GiteaEndpoints.issueListIssues,
       List("repos", owner, repo, "issues"),
-      issueQuery(params, page, pageSize),
-      response => GiteaResponseMapper.decodePage[Issue](response, page, pageSize)
+      params.page,
+      params.limit,
+      issueQuery(params, _, _)
     )
 
   def pinnedIssues(config: GiteaConfig, owner: String, repo: String): GiteaRequest[Chunk[Issue]] =
@@ -1147,15 +1115,13 @@ object GiteaRequests:
       repo: String,
       params: RepositoryCommentListParams = RepositoryCommentListParams.default
   ): GiteaRequest[Page[Comment]] =
-    val page = params.page.getOrElse(1)
-    val pageSize = params.limit.getOrElse(config.pageSize)
-
-    get(
+    paginatedWindow[Comment](
       config,
       GiteaEndpoints.issueGetRepoComments,
       List("repos", owner, repo, "issues", "comments"),
-      repositoryCommentQuery(params, page, pageSize),
-      response => GiteaResponseMapper.decodePage[Comment](response, page, pageSize)
+      params.page,
+      params.limit,
+      repositoryCommentQuery(params, _, _)
     )
 
   def issueComment(config: GiteaConfig, owner: String, repo: String, id: Long): GiteaRequest[Comment] =
@@ -1483,15 +1449,13 @@ object GiteaRequests:
       index: Long,
       params: IssueTrackedTimeListParams = IssueTrackedTimeListParams.default
   ): GiteaRequest[Page[TrackedTime]] =
-    val page = params.page.getOrElse(1)
-    val pageSize = params.limit.getOrElse(config.pageSize)
-
-    get(
+    paginatedWindow[TrackedTime](
       config,
       GiteaEndpoints.issueTrackedTimes,
       List("repos", owner, repo, "issues", index.toString, "times"),
-      trackedTimeQuery(params, page, pageSize),
-      response => GiteaResponseMapper.decodePage[TrackedTime](response, page, pageSize)
+      params.page,
+      params.limit,
+      trackedTimeQuery(params, _, _)
     )
 
   def addIssueTrackedTime(
@@ -1557,15 +1521,13 @@ object GiteaRequests:
 
   def notifications(config: GiteaConfig, params: NotificationListParams = NotificationListParams.default)
       : GiteaRequest[Page[NotificationThread]] =
-    val page = params.page.getOrElse(1)
-    val pageSize = params.limit.getOrElse(config.pageSize)
-
-    get(
+    paginatedWindow[NotificationThread](
       config,
       GiteaEndpoints.notifyGetList,
       List("notifications"),
-      notificationQuery(params, page, pageSize),
-      response => GiteaResponseMapper.decodePage[NotificationThread](response, page, pageSize)
+      params.page,
+      params.limit,
+      notificationQuery(params, _, _)
     )
 
   def notificationCount(config: GiteaConfig): GiteaRequest[NotificationCount] =
@@ -1678,7 +1640,7 @@ object GiteaRequests:
       endpoint: GiteaEndpoint,
       request: Request[Either[String, String]],
       decode: Response[String] => Either[GiteaError, A],
-      accept: String = MediaType.ApplicationJson.toString
+      accept: Accept = Accept.Json
   ): GiteaRequest[A] =
     GiteaRequest(
       endpoint = endpoint,
@@ -1703,7 +1665,7 @@ object GiteaRequests:
       path: List[String],
       query: List[(String, String)],
       decode: Response[String] => Either[GiteaError, A],
-      accept: String = MediaType.ApplicationJson.toString
+      accept: Accept = Accept.Json
   ): GiteaRequest[A] =
     jsonCall(config, endpoint, jsonRequest(config).get(apiUri(config.baseUrl, path, query)), decode, accept)
 
@@ -1719,7 +1681,7 @@ object GiteaRequests:
         .get(apiUri(config.baseUrl, path, query))
         .response(byteArrayResponse)
         .readTimeout(config.timeout)
-        .headers(commonHeaders(config, "application/octet-stream")),
+        .headers(commonHeaders(config, Accept.OctetStream)),
       decode = GiteaResponseMapper.decodeBytes,
       retryable = GiteaRequest.isReadOnly(endpoint)
     )
@@ -1733,7 +1695,7 @@ object GiteaRequests:
     GiteaDownloadRequest(
       endpoint = endpoint,
       uri = apiUri(config.baseUrl, path, query),
-      headers = commonHeaders(config, "application/octet-stream"),
+      headers = commonHeaders(config, Accept.OctetStream),
       timeout = config.timeout
     )
 
@@ -1818,7 +1780,7 @@ object GiteaRequests:
     baseUrl.addPath(List("api", "v1") ++ path).addParams(query*)
 
   // Derived once per config rather than per request; see GiteaConfig.headersAccepting.
-  private def commonHeaders(config: GiteaConfig, accept: String = MediaType.ApplicationJson.toString): Map[String, String] =
+  private def commonHeaders(config: GiteaConfig, accept: Accept = Accept.Json): Map[String, String] =
     config.headersAccepting(accept)
 
   private def issueQuery(params: IssueListParams, page: Int, pageSize: Int): List[(String, String)] =
@@ -1966,13 +1928,35 @@ object GiteaRequests:
       path: List[String],
       page: Int
   ): GiteaRequest[Page[A]] =
-    val pageSize = config.pageSize
+    paginatedWindow[A](config, endpoint, path, Some(page), None)
+
+  /** A paged GET whose window comes from a caller's `*Params`.
+    *
+    * The two numbers have to reach two places — the query that is sent and the
+    * `Page` that is built from the reply — and `Page.page` is only meaningful
+    * if they agree. Fourteen builders resolved them by hand and then passed
+    * them to both, so a stale one produced a `Page` that misreported which page
+    * it was, with nothing to catch it: the types are the same and no test
+    * compares them.
+    *
+    * Resolving once, here, is what makes them impossible to disagree.
+    */
+  private def paginatedWindow[A: JsonDecoder](
+      config: GiteaConfig,
+      endpoint: GiteaEndpoint,
+      path: List[String],
+      requestedPage: Option[Int],
+      requestedLimit: Option[Int],
+      query: (Int, Int) => List[(String, String)] = pageQuery
+  ): GiteaRequest[Page[A]] =
+    val page = requestedPage.getOrElse(1)
+    val pageSize = requestedLimit.getOrElse(config.pageSize)
 
     get(
       config,
       endpoint,
       path,
-      pageQuery(page, pageSize),
+      query(page, pageSize),
       response => GiteaResponseMapper.decodePage[A](response, page, pageSize)
     )
 

--- a/client/src/io/worxbend/gitea4s/http/GiteaRequests.scala
+++ b/client/src/io/worxbend/gitea4s/http/GiteaRequests.scala
@@ -589,12 +589,7 @@ object GiteaRequests:
       filepath: String,
       params: ContentsParams = ContentsParams.default
   ): GiteaRequest[Chunk[Byte]] =
-    getBytes(
-      config,
-      GiteaEndpoints.repoGetRawFile,
-      List("repos", owner, repo, "raw", filepath),
-      contentsQuery(params)
-    )
+    getBytes(config, rawFileTarget(owner, repo, filepath, params))
 
   def repoMediaFile(
       config: GiteaConfig,
@@ -603,12 +598,7 @@ object GiteaRequests:
       filepath: String,
       params: ContentsParams = ContentsParams.default
   ): GiteaRequest[Chunk[Byte]] =
-    getBytes(
-      config,
-      GiteaEndpoints.repoGetRawFileOrLFS,
-      List("repos", owner, repo, "media", filepath),
-      contentsQuery(params)
-    )
+    getBytes(config, mediaFileTarget(owner, repo, filepath, params))
 
   def repoGetArchive(
       config: GiteaConfig,
@@ -617,17 +607,12 @@ object GiteaRequests:
       archive: String,
       params: ArchiveParams = ArchiveParams.default
   ): GiteaRequest[Chunk[Byte]] =
-    getBytes(
-      config,
-      GiteaEndpoints.repoGetArchive,
-      List("repos", owner, repo, "archive", archive),
-      archiveQuery(params)
-    )
+    getBytes(config, archiveTarget(owner, repo, archive, params))
 
-  // Streaming download descriptors. These mirror the buffered repoRawFile /
-  // repoMediaFile / repoGetArchive builders above (same path encoding, query,
-  // and octet-stream headers) but defer the response shape to the caller, so a
-  // ZioStreams-capable backend can stream the body instead of buffering it.
+  // Streaming download descriptors. Each names the same target as its buffered
+  // counterpart above and differs only in deferring the response shape to the
+  // caller, so a ZioStreams-capable backend can stream the body instead of
+  // buffering it.
   def rawFileDownload(
       config: GiteaConfig,
       owner: String,
@@ -635,7 +620,7 @@ object GiteaRequests:
       filepath: String,
       params: ContentsParams = ContentsParams.default
   ): GiteaDownloadRequest =
-    download(config, GiteaEndpoints.repoGetRawFile, List("repos", owner, repo, "raw", filepath), contentsQuery(params))
+    download(config, rawFileTarget(owner, repo, filepath, params))
 
   def mediaFileDownload(
       config: GiteaConfig,
@@ -644,7 +629,7 @@ object GiteaRequests:
       filepath: String,
       params: ContentsParams = ContentsParams.default
   ): GiteaDownloadRequest =
-    download(config, GiteaEndpoints.repoGetRawFileOrLFS, List("repos", owner, repo, "media", filepath), contentsQuery(params))
+    download(config, mediaFileTarget(owner, repo, filepath, params))
 
   def archiveDownload(
       config: GiteaConfig,
@@ -653,7 +638,7 @@ object GiteaRequests:
       archive: String,
       params: ArchiveParams = ArchiveParams.default
   ): GiteaDownloadRequest =
-    download(config, GiteaEndpoints.repoGetArchive, List("repos", owner, repo, "archive", archive), archiveQuery(params))
+    download(config, archiveTarget(owner, repo, archive, params))
 
   def repoPullRequests(
       config: GiteaConfig,
@@ -1668,6 +1653,38 @@ object GiteaRequests:
       accept: Accept = Accept.Json
   ): GiteaRequest[A] =
     jsonCall(config, endpoint, jsonRequest(config).get(apiUri(config.baseUrl, path, query)), decode, accept)
+
+  /** Where one binary endpoint lives, named once.
+    *
+    * The buffered and streaming builders for raw files, media files and
+    * archives are the same request differing only in response handling, so each
+    * pair restated the same endpoint, path segments and query. A comment above
+    * the streaming three asserted they mirrored the buffered three — an
+    * invariant nothing enforced, and one this repo's tests could not have
+    * caught either, since `GiteaDownloadRequestsSpec` asserted only the
+    * streaming URI. Naming the target makes the two provably the same rather
+    * than reportedly so.
+    */
+  private final case class BinaryTarget(
+      endpoint: GiteaEndpoint,
+      path: List[String],
+      query: List[(String, String)]
+  )
+
+  private def rawFileTarget(owner: String, repo: String, filepath: String, params: ContentsParams): BinaryTarget =
+    BinaryTarget(GiteaEndpoints.repoGetRawFile, List("repos", owner, repo, "raw", filepath), contentsQuery(params))
+
+  private def mediaFileTarget(owner: String, repo: String, filepath: String, params: ContentsParams): BinaryTarget =
+    BinaryTarget(GiteaEndpoints.repoGetRawFileOrLFS, List("repos", owner, repo, "media", filepath), contentsQuery(params))
+
+  private def archiveTarget(owner: String, repo: String, archive: String, params: ArchiveParams): BinaryTarget =
+    BinaryTarget(GiteaEndpoints.repoGetArchive, List("repos", owner, repo, "archive", archive), archiveQuery(params))
+
+  private def getBytes(config: GiteaConfig, target: BinaryTarget): GiteaRequest[Chunk[Byte]] =
+    getBytes(config, target.endpoint, target.path, target.query)
+
+  private def download(config: GiteaConfig, target: BinaryTarget): GiteaDownloadRequest =
+    download(config, target.endpoint, target.path, target.query)
 
   private def getBytes(
       config: GiteaConfig,

--- a/client/src/io/worxbend/gitea4s/http/GiteaResponseMapper.scala
+++ b/client/src/io/worxbend/gitea4s/http/GiteaResponseMapper.scala
@@ -72,16 +72,7 @@ object GiteaResponseMapper:
       page: Int,
       pageSize: Int
   ): Either[GiteaError, Page[A]] =
-    decodeJson[Chunk[A]](response).map { values =>
-      val totalCount = longHeader(response, "x-total-count")
-      Page(
-        data = values,
-        totalCount = totalCount,
-        page = page,
-        pageSize = pageSize,
-        hasNext = hasNextPage(response, page, values.size, totalCount)
-      )
-    }
+    decodeJson[Chunk[A]](response).map(toPage(response, page, pageSize, _))
 
   def decodeTopicNamesPage(
       response: Response[String],
@@ -89,15 +80,7 @@ object GiteaResponseMapper:
       pageSize: Int
   ): Either[GiteaError, Page[String]] =
     decodeJson[TopicNames](response).map { value =>
-      val topics = value.topics.getOrElse(Nil)
-      val totalCount = longHeader(response, "x-total-count")
-      Page(
-        data = Chunk.fromIterable(topics),
-        totalCount = totalCount,
-        page = page,
-        pageSize = pageSize,
-        hasNext = hasNextPage(response, page, topics.size, totalCount)
-      )
+      toPage(response, page, pageSize, Chunk.fromIterable(value.topics.getOrElse(Nil)))
     }
 
   def decodeUserSearchPage(
@@ -106,16 +89,33 @@ object GiteaResponseMapper:
       pageSize: Int
   ): Either[GiteaError, Page[User]] =
     decodeJson[UserSearchResults](response).map { value =>
-      val users = value.data.getOrElse(Chunk.empty)
-      val totalCount = longHeader(response, "x-total-count")
-      Page(
-        data = users,
-        totalCount = totalCount,
-        page = page,
-        pageSize = pageSize,
-        hasNext = hasNextPage(response, page, users.size, totalCount)
-      )
+      toPage(response, page, pageSize, value.data.getOrElse(Chunk.empty))
     }
+
+  /** Assembles the `Page` around whatever the decoder extracted.
+    *
+    * The three page decoders differ only in how they get from the body to a
+    * `Chunk`; each then read `x-total-count` and hand-built the same five
+    * fields. Taking the values here rather than a count is the point: the
+    * received size is derived once, next to the header it is compared against,
+    * so no call site can pass `pageSize` where the number of items received is
+    * required — which is exactly the bug `hasNextPage` documents at length
+    * below.
+    */
+  private def toPage[A](
+      response: Response[String],
+      page: Int,
+      pageSize: Int,
+      values: Chunk[A]
+  ): Page[A] =
+    val totalCount = longHeader(response, "x-total-count")
+    Page(
+      data = values,
+      totalCount = totalCount,
+      page = page,
+      pageSize = pageSize,
+      hasNext = hasNextPage(response, page, values.size, totalCount)
+    )
 
   def toError(response: Response[String]): GiteaError =
     val body = truncate(response.body)

--- a/client/src/io/worxbend/gitea4s/http/IssueCommentListParams.scala
+++ b/client/src/io/worxbend/gitea4s/http/IssueCommentListParams.scala
@@ -9,13 +9,3 @@ final case class IssueCommentListParams(
 
 object IssueCommentListParams:
   val default: IssueCommentListParams = IssueCommentListParams()
-
-final case class RepositoryCommentListParams(
-    since: Option[Instant] = None,
-    before: Option[Instant] = None,
-    page: Option[Int] = None,
-    limit: Option[Int] = None
-)
-
-object RepositoryCommentListParams:
-  val default: RepositoryCommentListParams = RepositoryCommentListParams()

--- a/client/src/io/worxbend/gitea4s/http/RepositoryCommentListParams.scala
+++ b/client/src/io/worxbend/gitea4s/http/RepositoryCommentListParams.scala
@@ -1,0 +1,13 @@
+package io.worxbend.gitea4s.http
+
+import java.time.Instant
+
+final case class RepositoryCommentListParams(
+    since: Option[Instant] = None,
+    before: Option[Instant] = None,
+    page: Option[Int] = None,
+    limit: Option[Int] = None
+)
+
+object RepositoryCommentListParams:
+  val default: RepositoryCommentListParams = RepositoryCommentListParams()

--- a/client/src/io/worxbend/gitea4s/internal/GiteaRequestExecutor.scala
+++ b/client/src/io/worxbend/gitea4s/internal/GiteaRequestExecutor.scala
@@ -65,7 +65,19 @@ final class GiteaRequestExecutor(
               attempts = telemetry.attempts
             )
           )
+          // `catchAllCause` covers an observer that *fails*; it does nothing
+          // about one that never finishes. The scaladoc asks observers not to
+          // block, and then recommends offering to a `Queue` — which is exactly
+          // what suspends forever once that queue is full. Until this bound
+          // existed, such an observer withheld a result the client had already
+          // computed, indefinitely.
+          //
+          // `disconnect` puts the callback on its own fiber so the timeout can
+          // actually interrupt it rather than waiting for the next yield.
+          .disconnect
+          .timeout(GiteaRequestExecutor.observerBudget)
           .catchAllCause(_ => ZIO.unit)
+          .unit
       }
       value <- exit
     yield value
@@ -183,6 +195,20 @@ object GiteaRequestExecutor:
     * sttp's own timeouts, which stay retryable — keep behaving as before.
     */
   private final class AttemptBudgetExhausted(message: String) extends TimeoutException(message)
+
+  /** How long a `GiteaObserver` callback may take before it is abandoned.
+    *
+    * Generous for anything an observer should be doing — recording a metric or
+    * emitting a log line is microseconds — and short enough that a misbehaving
+    * one cannot hold a finished request. When it expires the event is dropped
+    * rather than retried: it is telemetry, and the request's result matters
+    * more.
+    *
+    * The honest limit: this frees the *caller*. An observer that blocks its
+    * carrier thread inside `ZIO.succeed` still ties up that thread, because
+    * nothing can interrupt code that never yields.
+    */
+  private val observerBudget: Duration = Duration.ofSeconds(1)
 
   private def attemptBudgetExhausted(after: Duration): GiteaError =
     GiteaError.TransportError(new AttemptBudgetExhausted(s"Gitea request attempt exceeded its time budget of $after"))

--- a/client/src/io/worxbend/gitea4s/internal/Pagination.scala
+++ b/client/src/io/worxbend/gitea4s/internal/Pagination.scala
@@ -14,6 +14,11 @@ object Pagination:
 
   /** Streams every item from `start` onwards.
     *
+    * A page-offset scan of a live collection, not a snapshot: each page is a
+    * separate request, so an insert or delete between two of them shifts
+    * everything after it and an item can be emitted twice or skipped. Callers
+    * that need exactly-once handling should key on the item's id.
+    *
     * This exists because the two paging fields on the public `*Params` types
     * were not honoured symmetrically: `limit` reached the request, while `page`
     * was overwritten with 1 on every call and so was silently discarded. A

--- a/client/src/io/worxbend/gitea4s/internal/SttpIssuesApi.scala
+++ b/client/src/io/worxbend/gitea4s/internal/SttpIssuesApi.scala
@@ -41,7 +41,7 @@ private[gitea4s] final class SttpIssuesApi(config: GiteaConfig, executor: GiteaR
   override def list(
       owner: String,
       repo: String,
-      params: IssueListParams = IssueListParams.default
+      params: IssueListParams
   ): ZStream[Any, GiteaError, Issue] =
     Pagination.paginatedFrom(params.page.getOrElse(1)) { page =>
       executor.send(GiteaRequests.issues(config, owner, repo, params.copy(page = Some(page))))
@@ -117,14 +117,14 @@ private[gitea4s] final class SttpIssuesApi(config: GiteaConfig, executor: GiteaR
       owner: String,
       repo: String,
       index: Long,
-      params: IssueCommentListParams = IssueCommentListParams.default
+      params: IssueCommentListParams
   ): IO[GiteaError, Chunk[Comment]] =
     executor.send(GiteaRequests.issueComments(config, owner, repo, index, params))
 
   override def repositoryComments(
       owner: String,
       repo: String,
-      params: RepositoryCommentListParams = RepositoryCommentListParams.default
+      params: RepositoryCommentListParams
   ): ZStream[Any, GiteaError, Comment] =
     Pagination.paginatedFrom(params.page.getOrElse(1)) { page =>
       executor.send(GiteaRequests.repoIssueComments(config, owner, repo, params.copy(page = Some(page))))
@@ -229,7 +229,7 @@ private[gitea4s] final class SttpIssuesApi(config: GiteaConfig, executor: GiteaR
       owner: String,
       repo: String,
       index: Long,
-      params: IssueTrackedTimeListParams = IssueTrackedTimeListParams.default
+      params: IssueTrackedTimeListParams
   ): ZStream[Any, GiteaError, TrackedTime] =
     Pagination.paginatedFrom(params.page.getOrElse(1)) { page =>
       executor.send(GiteaRequests.issueTrackedTimes(config, owner, repo, index, params.copy(page = Some(page))))

--- a/client/src/io/worxbend/gitea4s/internal/SttpNotificationsApi.scala
+++ b/client/src/io/worxbend/gitea4s/internal/SttpNotificationsApi.scala
@@ -11,7 +11,7 @@ import zio.stream.ZStream
 private[gitea4s] final class SttpNotificationsApi(config: GiteaConfig, executor: GiteaRequestExecutor)
     extends NotificationsApi:
   override def list(
-      params: NotificationListParams = NotificationListParams.default
+      params: NotificationListParams
   ): ZStream[Any, GiteaError, NotificationThread] =
     Pagination.paginatedFrom(params.page.getOrElse(1)) { page =>
       executor.send(GiteaRequests.notifications(config, params.copy(page = Some(page))))

--- a/client/src/io/worxbend/gitea4s/internal/SttpPullsApi.scala
+++ b/client/src/io/worxbend/gitea4s/internal/SttpPullsApi.scala
@@ -32,7 +32,7 @@ private[gitea4s] final class SttpPullsApi(config: GiteaConfig, executor: GiteaRe
   override def list(
       owner: String,
       repo: String,
-      params: PullRequestListParams = PullRequestListParams.default
+      params: PullRequestListParams
   ): ZStream[Any, GiteaError, PullRequest] =
     Pagination.paginatedFrom(params.page.getOrElse(1)) { page =>
       executor.send(GiteaRequests.repoPullRequests(config, owner, repo, params.copy(page = Some(page))))
@@ -172,7 +172,7 @@ private[gitea4s] final class SttpPullsApi(config: GiteaConfig, executor: GiteaRe
       repo: String,
       index: Long,
       diffType: PullRequestDiffType,
-      binary: Option[Boolean] = None
+      binary: Option[Boolean]
   ): IO[GiteaError, String] =
     executor.send(GiteaRequests.repoPullRequestDiffOrPatch(config, owner, repo, index, diffType, binary))
 
@@ -180,7 +180,7 @@ private[gitea4s] final class SttpPullsApi(config: GiteaConfig, executor: GiteaRe
       owner: String,
       repo: String,
       index: Long,
-      params: PullRequestFilesParams = PullRequestFilesParams.default
+      params: PullRequestFilesParams
   ): ZStream[Any, GiteaError, ChangedFile] =
     Pagination.paginatedFrom(params.page.getOrElse(1)) { page =>
       executor.send(GiteaRequests.repoPullRequestFiles(config, owner, repo, index, params.copy(page = Some(page))))
@@ -190,7 +190,7 @@ private[gitea4s] final class SttpPullsApi(config: GiteaConfig, executor: GiteaRe
       owner: String,
       repo: String,
       index: Long,
-      params: PullRequestCommitsParams = PullRequestCommitsParams.default
+      params: PullRequestCommitsParams
   ): ZStream[Any, GiteaError, Commit] =
     Pagination.paginatedFrom(params.page.getOrElse(1)) { page =>
       executor.send(GiteaRequests.repoPullRequestCommits(config, owner, repo, index, params.copy(page = Some(page))))

--- a/client/src/io/worxbend/gitea4s/internal/SttpReleasesApi.scala
+++ b/client/src/io/worxbend/gitea4s/internal/SttpReleasesApi.scala
@@ -12,7 +12,7 @@ private[gitea4s] final class SttpReleasesApi(config: GiteaConfig, executor: Gite
   override def list(
       owner: String,
       repo: String,
-      params: ReleaseListParams = ReleaseListParams.default
+      params: ReleaseListParams
   ): ZStream[Any, GiteaError, Release] =
     Pagination.paginatedFrom(params.page.getOrElse(1)) { page =>
       executor.send(GiteaRequests.repoReleases(config, owner, repo, params.copy(page = Some(page))))

--- a/client/src/io/worxbend/gitea4s/internal/SttpReposApi.scala
+++ b/client/src/io/worxbend/gitea4s/internal/SttpReposApi.scala
@@ -48,7 +48,7 @@ private[gitea4s] final class SttpReposApi(config: GiteaConfig, executor: GiteaRe
       owner: String,
       repo: String,
       sha: String,
-      params: SingleCommitParams = SingleCommitParams.default
+      params: SingleCommitParams
   ): IO[GiteaError, Commit] =
     executor.send(GiteaRequests.repoSingleCommit(config, owner, repo, sha, params))
 
@@ -64,7 +64,7 @@ private[gitea4s] final class SttpReposApi(config: GiteaConfig, executor: GiteaRe
       owner: String,
       repo: String,
       sha: String,
-      params: CommitNoteParams = CommitNoteParams.default
+      params: CommitNoteParams
   ): IO[GiteaError, Note] =
     executor.send(GiteaRequests.repoCommitNote(config, owner, repo, sha, params))
 
@@ -72,7 +72,7 @@ private[gitea4s] final class SttpReposApi(config: GiteaConfig, executor: GiteaRe
       owner: String,
       repo: String,
       sha: String,
-      params: GitTreeParams = GitTreeParams.default
+      params: GitTreeParams
   ): IO[GiteaError, GitTreeResponse] =
     executor.send(GiteaRequests.gitTree(config, owner, repo, sha, params))
 
@@ -107,7 +107,7 @@ private[gitea4s] final class SttpReposApi(config: GiteaConfig, executor: GiteaRe
       owner: String,
       repo: String,
       filepath: String,
-      params: ContentsParams = ContentsParams.default
+      params: ContentsParams
   ): IO[GiteaError, Chunk[Byte]] =
     executor.send(GiteaRequests.repoRawFile(config, owner, repo, filepath, params))
 
@@ -115,7 +115,7 @@ private[gitea4s] final class SttpReposApi(config: GiteaConfig, executor: GiteaRe
       owner: String,
       repo: String,
       filepath: String,
-      params: ContentsParams = ContentsParams.default
+      params: ContentsParams
   ): IO[GiteaError, Chunk[Byte]] =
     executor.send(GiteaRequests.repoMediaFile(config, owner, repo, filepath, params))
 
@@ -123,7 +123,7 @@ private[gitea4s] final class SttpReposApi(config: GiteaConfig, executor: GiteaRe
       owner: String,
       repo: String,
       archive: String,
-      params: ArchiveParams = ArchiveParams.default
+      params: ArchiveParams
   ): IO[GiteaError, Chunk[Byte]] =
     executor.send(GiteaRequests.repoGetArchive(config, owner, repo, archive, params))
 
@@ -168,7 +168,7 @@ private[gitea4s] final class SttpReposApi(config: GiteaConfig, executor: GiteaRe
 
   override def list(
       owner: String,
-      params: RepoListParams = RepoListParams.default
+      params: RepoListParams
   ): ZStream[Any, GiteaError, Repository] =
     Pagination.paginatedFrom(params.page.getOrElse(1)) { page =>
       executor.send(GiteaRequests.userRepos(config, owner, params.copy(page = Some(page))))
@@ -217,7 +217,7 @@ private[gitea4s] final class SttpReposApi(config: GiteaConfig, executor: GiteaRe
       owner: String,
       repo: String,
       ref: String,
-      params: CombinedStatusParams = CombinedStatusParams.default
+      params: CombinedStatusParams
   ): IO[GiteaError, CombinedStatus] =
     executor.send(GiteaRequests.repoCombinedStatusByRef(config, owner, repo, ref, params))
 
@@ -225,7 +225,7 @@ private[gitea4s] final class SttpReposApi(config: GiteaConfig, executor: GiteaRe
       owner: String,
       repo: String,
       ref: String,
-      params: CommitStatusListParams = CommitStatusListParams.default
+      params: CommitStatusListParams
   ): ZStream[Any, GiteaError, CommitStatus] =
     Pagination.paginatedFrom(params.page.getOrElse(1)) { page =>
       executor.send(GiteaRequests.repoStatusesByRef(config, owner, repo, ref, params.copy(page = Some(page))))
@@ -235,7 +235,7 @@ private[gitea4s] final class SttpReposApi(config: GiteaConfig, executor: GiteaRe
       owner: String,
       repo: String,
       sha: String,
-      params: CommitStatusListParams = CommitStatusListParams.default
+      params: CommitStatusListParams
   ): ZStream[Any, GiteaError, CommitStatus] =
     Pagination.paginatedFrom(params.page.getOrElse(1)) { page =>
       executor.send(GiteaRequests.repoStatuses(config, owner, repo, sha, params.copy(page = Some(page))))

--- a/client/src/io/worxbend/gitea4s/observability/GiteaObserver.scala
+++ b/client/src/io/worxbend/gitea4s/observability/GiteaObserver.scala
@@ -50,9 +50,15 @@ final case class RequestEvent(
   *
   * Because an observer runs inline on the request's fiber, it must not block
   * and must not perform unbounded I/O: a slow observer delays a result that has
-  * already been computed, and one that never completes withholds it entirely.
-  * Hand work off instead — offer to a `Queue` the application drains elsewhere,
-  * or use ZIO's own metrics, which are non-blocking.
+  * already been computed. Hand work off instead — offer to a `Queue` the
+  * application drains elsewhere, or use ZIO's own metrics, which are
+  * non-blocking.
+  *
+  * A callback that has not finished within one second is abandoned and its
+  * event dropped, so an observer can no longer withhold a completed result
+  * indefinitely. Note the limit: that frees the caller, not the thread. An
+  * observer that blocks its carrier thread inside `ZIO.succeed` still ties up
+  * that thread, because nothing can interrupt code that never yields.
   *
   * Set one through `GiteaConfig.withObserver(...)`, for example
   * `config.withObserver(GiteaObserver.logging ++ GiteaObserver.metrics)`.

--- a/client/src/io/worxbend/gitea4s/observability/GiteaObserver.scala
+++ b/client/src/io/worxbend/gitea4s/observability/GiteaObserver.scala
@@ -91,10 +91,31 @@ object GiteaObserver:
         case RequestOutcome.Success =>
           ZIO.logDebug(s"gitea4s ${e.method} ${e.path} (${e.operationId}) succeeded in ${ms}ms$retries")
         case RequestOutcome.Failure(error) =>
+          val status = event.status.fold("")(code => s" status=$code")
           ZIO.logWarning(
-            s"gitea4s ${e.method} ${e.path} (${e.operationId}) failed in ${ms}ms$retries: " +
-              error.getClass.getSimpleName
+            s"gitea4s ${e.method} ${e.path} (${e.operationId}) failed in ${ms}ms$retries$status: " +
+              describe(error)
           )
+
+  /** Names a failure precisely enough to act on, and nothing more.
+    *
+    * `getClass.getSimpleName` collapsed every network problem into the single
+    * word `TransportError`: DNS failure, connection refused, a TLS handshake
+    * error, a read timeout and the executor's own exhausted attempt budget all
+    * logged identically, which is no help at 3am. `ServerError` was equally
+    * mute about *which* 5xx, while `RequestEvent.status` was carried and never
+    * logged at all.
+    *
+    * Unwraps exactly one level. Only type names and a status code are
+    * produced, so the guarantee above — never response bodies, never
+    * credentials — still holds: an exception *message* can quote a URL or a
+    * header and is deliberately not included.
+    */
+  private def describe(error: GiteaError): String =
+    error match
+      case GiteaError.TransportError(cause) => s"TransportError(${cause.getClass.getSimpleName})"
+      case GiteaError.ServerError(status, _) => s"ServerError($status)"
+      case other => other.getClass.getSimpleName
 
   /** Latency buckets, in milliseconds.
     *

--- a/client/test/src/io/worxbend/gitea4s/GiteaConfigSpec.scala
+++ b/client/test/src/io/worxbend/gitea4s/GiteaConfigSpec.scala
@@ -206,6 +206,59 @@ object GiteaConfigSpec extends ZIOSpecDefault:
           !message.contains("password-secret")
         )
       },
+      test("rejects a HOCON duration written without a unit") {
+        // Typesafe Config reads a bare number in duration position as
+        // milliseconds, so `timeout = 30` used to parse as 30ms and give every
+        // request a 30-millisecond budget. The identical GITEA_TIMEOUT=30 was
+        // rejected, so the same text meant two different things and the wrong
+        // one was silent.
+        val bare = GiteaConfig.fromTypesafeString(
+          """gitea4s { url = "https://gitea.example", token = "t", timeout = 30 }"""
+        )
+        val quoted = GiteaConfig.fromTypesafeString(
+          """gitea4s { url = "https://gitea.example", token = "t", timeout = "30" }"""
+        )
+
+        assertTrue(
+          bare.isLeft,
+          quoted.isLeft,
+          bare.left.toOption.map(_.toString).getOrElse("").contains("30s")
+        )
+      },
+      test("accepts the HOCON duration spellings Typesafe config allows") {
+        // The check rejects only the unitless form. HOCON's own spellings must
+        // keep working, including ones Scala's Duration parser would reject.
+        val seconds = GiteaConfig.fromTypesafeString(
+          """gitea4s { url = "https://gitea.example", token = "t", timeout = 30s }"""
+        )
+        val spaced = GiteaConfig.fromTypesafeString(
+          """gitea4s { url = "https://gitea.example", token = "t", timeout = 2 minutes }"""
+        )
+
+        assertTrue(
+          seconds.map(_.timeout) == Right(30.seconds),
+          spaced.map(_.timeout) == Right(2.minutes)
+        )
+      },
+      test("rejects a setting spelled the way the environment spells it") {
+        // `maxRetries` is simply a different key from `max-retries`, so it used
+        // to be read by nobody: the config loaded and the setting did nothing.
+        val result = GiteaConfig.fromTypesafeString(
+          """gitea4s { url = "https://gitea.example", token = "t", maxRetries = 9 }"""
+        )
+        val message = result.left.toOption.map(_.toString).getOrElse("")
+
+        assertTrue(result.isLeft, message.contains("maxRetries"), message.contains("max-retries"))
+      },
+      test("leaves a genuinely unrelated key alone") {
+        // Applications legitimately keep their own settings beside these, so
+        // only near misses are rejected.
+        val result = GiteaConfig.fromTypesafeString(
+          """gitea4s { url = "https://gitea.example", token = "t", my-own-setting = 7 }"""
+        )
+
+        assertTrue(result.map(_.maxRetries) == Right(GiteaConfig.defaultMaxRetries))
+      },
       test("rejects a token with a control character in the middle") {
         // Trimming only strips the ends. An embedded CR/LF used to survive
         // into `Authorization: token ...` and fail later — as an untyped JDK

--- a/client/test/src/io/worxbend/gitea4s/GiteaConfigSpec.scala
+++ b/client/test/src/io/worxbend/gitea4s/GiteaConfigSpec.scala
@@ -464,20 +464,23 @@ object GiteaConfigSpec extends ZIOSpecDefault:
 
         assertTrue(
           config.jsonHeaders eq config.jsonHeaders,
-          config.headersAccepting("application/json") eq config.jsonHeaders,
-          config.headersAccepting("application/octet-stream") eq config.octetStreamHeaders,
-          config.headersAccepting("text/plain") eq config.textPlainHeaders
+          config.headersAccepting(Accept.Json) eq config.jsonHeaders,
+          config.headersAccepting(Accept.OctetStream) eq config.octetStreamHeaders,
+          config.headersAccepting(Accept.TextPlain) eq config.textPlainHeaders
         )
       },
-      test("sends the requested Accept value even for a content type it does not memoise") {
+      test("sends the Accept value asked for, alongside the credentials") {
         // A two-way switch here would have silently answered text/plain
-        // requests with the octet-stream header set.
+        // requests with the octet-stream header set. The arbitrary-media-type
+        // case this replaces is now unrepresentable: `Accept` is a closed type,
+        // so an unlisted content type does not compile.
         val config = GiteaConfig.withToken(uri, "t")
 
         assertTrue(
-          config.headersAccepting("text/plain").get("Accept").contains("text/plain"),
-          config.headersAccepting("application/vnd.custom").get("Accept").contains("application/vnd.custom"),
-          config.headersAccepting("application/vnd.custom").get("Authorization").contains("token t")
+          Accept.values.forall(accept =>
+            config.headersAccepting(accept).get("Accept").contains(accept.headerValue)
+          ),
+          config.headersAccepting(Accept.TextPlain).get("Authorization").contains("token t")
         )
       },
       test("rejects invalid Typesafe retry counts") {

--- a/client/test/src/io/worxbend/gitea4s/GiteaConfigSpec.scala
+++ b/client/test/src/io/worxbend/gitea4s/GiteaConfigSpec.scala
@@ -206,6 +206,16 @@ object GiteaConfigSpec extends ZIOSpecDefault:
           !message.contains("password-secret")
         )
       },
+      test("builds the basic-auth header the way HTTP specifies") {
+        // `Auth.Basic` header construction had no hermetic assertion at all —
+        // only the live integration suite would have caught a wrong encoding,
+        // and only as a 401.
+        val expected =
+          "Basic " + java.util.Base64.getEncoder.encodeToString("alice:hunter2".getBytes("UTF-8"))
+        val config = GiteaConfig.withBasic(Uri.unsafeParse("https://gitea.example"), "alice", "hunter2")
+
+        assertTrue(config.jsonHeaders.get("Authorization").contains(expected))
+      },
       test("rejects a HOCON duration written without a unit") {
         // Typesafe Config reads a bare number in duration position as
         // milliseconds, so `timeout = 30` used to parse as 30ms and give every

--- a/client/test/src/io/worxbend/gitea4s/GiteaConfigSpec.scala
+++ b/client/test/src/io/worxbend/gitea4s/GiteaConfigSpec.scala
@@ -206,6 +206,51 @@ object GiteaConfigSpec extends ZIOSpecDefault:
           !message.contains("password-secret")
         )
       },
+      test("reads the same settings from the environment as from HOCON") {
+        // `fromEnv` bound five settings while the HOCON reader bound seven, so
+        // an env-configured deployment could not change its User-Agent at all
+        // and could not send X-Gitea-OTP.
+        val env = GiteaConfig.fromEnv(
+          baseEnv ++ Map(
+            GiteaConfig.Env.token -> "t",
+            GiteaConfig.Env.userAgent -> "my-app/2.0",
+            GiteaConfig.Env.otp -> "123456"
+          )
+        )
+        val hocon = GiteaConfig.fromTypesafeString(
+          """gitea4s {
+            |  url = "https://gitea.example/root"
+            |  token = "t"
+            |  user-agent = "my-app/2.0"
+            |  otp = "123456"
+            |}""".stripMargin
+        )
+
+        assertTrue(
+          env.map(_.userAgent) == Right(Some("my-app/2.0")),
+          env.map(_.otp) == Right(Some("123456")),
+          // The whole config, not just the two new fields.
+          env == hocon
+        )
+      },
+      test("defaults the User-Agent identically from either source") {
+        val env = GiteaConfig.fromEnv(baseEnv + (GiteaConfig.Env.token -> "t"))
+        val hocon = GiteaConfig.fromTypesafeString(
+          """gitea4s { url = "https://gitea.example/root", token = "t" }"""
+        )
+
+        assertTrue(env.map(_.userAgent) == Right(Some("gitea4s")), env.map(_.userAgent) == hocon.map(_.userAgent))
+      },
+      test("rejects control characters in the new environment variables too") {
+        val agent = GiteaConfig.fromEnv(baseEnv ++ Map(GiteaConfig.Env.userAgent -> "bad\ragent"))
+        val otp = GiteaConfig.fromEnv(baseEnv ++ Map(GiteaConfig.Env.otp -> "12\n34"))
+
+        assertTrue(
+          agent.isLeft,
+          otp.isLeft,
+          !otp.left.toOption.map(_.toString).getOrElse("").contains("1234")
+        )
+      },
       test("builds the basic-auth header the way HTTP specifies") {
         // `Auth.Basic` header construction had no hermetic assertion at all —
         // only the live integration suite would have caught a wrong encoding,

--- a/client/test/src/io/worxbend/gitea4s/http/GiteaDownloadRequestsSpec.scala
+++ b/client/test/src/io/worxbend/gitea4s/http/GiteaDownloadRequestsSpec.scala
@@ -44,4 +44,32 @@ object GiteaDownloadRequestsSpec extends ZIOSpecDefault:
           req.uri.params.getMulti("path").contains(Seq("src", "docs/readme.md"))
         )
       }
+      ,
+      test("each streaming download targets exactly what its buffered twin does") {
+        // The two builders for each binary endpoint used to restate the same
+        // endpoint, path and query, under a comment claiming they mirrored one
+        // another. Nothing checked it, and this spec could not have: it asserts
+        // only the streaming URI, so the buffered side could drift freely.
+        val pairs = List(
+          (
+            GiteaRequests.repoRawFile(config, "alice", "api", "docs/read me.md"),
+            GiteaRequests.rawFileDownload(config, "alice", "api", "docs/read me.md")
+          ),
+          (
+            GiteaRequests.repoMediaFile(config, "alice", "api", "docs/read me.md"),
+            GiteaRequests.mediaFileDownload(config, "alice", "api", "docs/read me.md")
+          ),
+          (
+            GiteaRequests.repoGetArchive(config, "alice", "api", "main.zip"),
+            GiteaRequests.archiveDownload(config, "alice", "api", "main.zip")
+          )
+        )
+
+        assertTrue(
+          pairs.forall((buffered, streamed) => buffered.endpoint == streamed.endpoint),
+          pairs.forall((buffered, streamed) => buffered.request.uri == streamed.uri),
+          // Same octet-stream envelope, so the server cannot answer them differently.
+          pairs.forall((buffered, streamed) => buffered.request.header("Accept") == streamed.headers.get("Accept"))
+        )
+      }
     )

--- a/client/test/src/io/worxbend/gitea4s/http/GiteaRequestsSpec.scala
+++ b/client/test/src/io/worxbend/gitea4s/http/GiteaRequestsSpec.scala
@@ -105,10 +105,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
 
         assertTrue(
           endpoint == GiteaEndpoints.orgGet,
-          endpoint.operationId == "orgGet",
-          endpoint.path == "/orgs/{org}",
-          endpoint.parameters.map(_.name) == List("org"),
-          endpoint.response == "#/responses/Organization",
           request.method == Method.GET,
           request.uri.toString == "https://gitea.example/root/api/v1/orgs/space%20org%2Fslash",
           request.header("Accept").contains("application/json")
@@ -121,10 +117,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
 
         assertTrue(
           endpoint == GiteaEndpoints.orgListMembers,
-          endpoint.operationId == "orgListMembers",
-          endpoint.path == "/orgs/{org}/members",
-          endpoint.parameters.map(_.name) == List("org", "page", "limit"),
-          endpoint.response == "#/responses/UserList",
           request.method == Method.GET,
           request.uri.toString.contains("/api/v1/orgs/space%20org%2Fslash/members?"),
           request.uri.paramsMap.get("page").contains("2"),
@@ -138,10 +130,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
 
         assertTrue(
           endpoint == GiteaEndpoints.orgListPublicMembers,
-          endpoint.operationId == "orgListPublicMembers",
-          endpoint.path == "/orgs/{org}/public_members",
-          endpoint.parameters.map(_.name) == List("org", "page", "limit"),
-          endpoint.response == "#/responses/UserList",
           request.method == Method.GET,
           request.uri.toString.contains("/api/v1/orgs/space%20org%2Fslash/public_members?"),
           request.uri.paramsMap.get("page").contains("3"),
@@ -156,10 +144,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
 
         assertTrue(
           endpoint == GiteaEndpoints.orgListRepos,
-          endpoint.operationId == "orgListRepos",
-          endpoint.path == "/orgs/{org}/repos",
-          endpoint.parameters.map(_.name) == List("org", "page", "limit"),
-          endpoint.response == "#/responses/RepositoryList",
           request.method == Method.GET,
           request.uri.toString.contains("/api/v1/orgs/space%20org%2Fslash/repos?"),
           request.uri.paramsMap.get("page").contains("4"),
@@ -174,9 +158,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
 
         assertTrue(
           endpoint == GiteaEndpoints.userListRepos,
-          endpoint.operationId == "userListRepos",
-          endpoint.path == "/users/{username}/repos",
-          endpoint.parameters.map(_.name) == List("username", "page", "limit"),
           request.method == Method.GET,
           request.uri.toString.contains("/api/v1/users/space%20user%2Fslash/repos?"),
           request.uri.paramsMap.get("page").contains("2"),
@@ -190,9 +171,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
 
         assertTrue(
           endpoint == GiteaEndpoints.repoListTopics,
-          endpoint.operationId == "repoListTopics",
-          endpoint.path == "/repos/{owner}/{repo}/topics",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "page", "limit"),
           request.method == Method.GET,
           request.uri.toString.contains("/api/v1/repos/worx%20bend/gitea%2Fscala/topics?"),
           request.uri.paramsMap.get("page").contains("3"),
@@ -207,10 +185,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoNewPinAllowed,
           endpoint.method == "GET",
-          endpoint.operationId == "repoNewPinAllowed",
-          endpoint.path == "/repos/{owner}/{repo}/new_pin_allowed",
-          endpoint.parameters.map(_.name) == List("owner", "repo"),
-          endpoint.response == "#/responses/RepoNewIssuePinsAllowed",
           request.method == Method.GET,
           request.uri.toString == "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/new_pin_allowed",
           built.retryable == true
@@ -228,10 +202,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoGetAssignees,
           endpoint.method == "GET",
-          endpoint.operationId == "repoGetAssignees",
-          endpoint.path == "/repos/{owner}/{repo}/assignees",
-          endpoint.parameters.map(_.name) == List("owner", "repo"),
-          endpoint.response == "#/responses/UserList",
           request.method == Method.GET,
           request.uri.toString ==
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/assignees",
@@ -265,10 +235,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoGetReviewers,
           endpoint.method == "GET",
-          endpoint.operationId == "repoGetReviewers",
-          endpoint.path == "/repos/{owner}/{repo}/reviewers",
-          endpoint.parameters.map(_.name) == List("owner", "repo"),
-          endpoint.response == "#/responses/UserList",
           request.method == Method.GET,
           request.uri.toString ==
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/reviewers",
@@ -302,10 +268,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoListStargazers,
           endpoint.method == "GET",
-          endpoint.operationId == "repoListStargazers",
-          endpoint.path == "/repos/{owner}/{repo}/stargazers",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "page", "limit"),
-          endpoint.response == "#/responses/UserList",
           request.method == Method.GET,
           request.uri.toString.contains("/api/v1/repos/worx%20bend/gitea%2Fscala/stargazers?"),
           request.uri.path ==
@@ -362,10 +324,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoListSubscribers,
           endpoint.method == "GET",
-          endpoint.operationId == "repoListSubscribers",
-          endpoint.path == "/repos/{owner}/{repo}/subscribers",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "page", "limit"),
-          endpoint.response == "#/responses/UserList",
           request.method == Method.GET,
           request.uri.toString.contains("/api/v1/repos/worx%20bend/gitea%2Fscala/subscribers?"),
           request.uri.path ==
@@ -419,10 +377,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
 
         assertTrue(
           endpoint == GiteaEndpoints.repoListBranches,
-          endpoint.operationId == "repoListBranches",
-          endpoint.path == "/repos/{owner}/{repo}/branches",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "page", "limit"),
-          endpoint.response == "#/responses/BranchList",
           request.method == Method.GET,
           request.uri.toString.contains("/api/v1/repos/worx%20bend/gitea%2Fscala/branches?"),
           request.uri.paramsMap.get("page").contains("3"),
@@ -436,10 +390,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
 
         assertTrue(
           endpoint == GiteaEndpoints.repoListTags,
-          endpoint.operationId == "repoListTags",
-          endpoint.path == "/repos/{owner}/{repo}/tags",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "page", "limit"),
-          endpoint.response == "#/responses/TagList",
           request.method == Method.GET,
           request.uri.toString.contains("/api/v1/repos/worx%20bend/gitea%2Fscala/tags?"),
           request.uri.paramsMap.get("page").contains("4"),
@@ -458,10 +408,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoGetLanguages,
           endpoint.method == "GET",
-          endpoint.operationId == "repoGetLanguages",
-          endpoint.path == "/repos/{owner}/{repo}/languages",
-          endpoint.parameters.map(_.name) == List("owner", "repo"),
-          endpoint.response == "#/responses/LanguageStatistics",
           request.method == Method.GET,
           request.uri.toString ==
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/languages",
@@ -502,10 +448,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoSigningKey,
           endpoint.method == "GET",
-          endpoint.operationId == "repoSigningKey",
-          endpoint.path == "/repos/{owner}/{repo}/signing-key.gpg",
-          endpoint.parameters.map(_.name) == List("owner", "repo"),
-          endpoint.response == "#/responses/string",
           request.method == Method.GET,
           request.uri.toString ==
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/signing-key.gpg",
@@ -535,10 +477,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoGetTag,
           endpoint.method == "GET",
-          endpoint.operationId == "repoGetTag",
-          endpoint.path == "/repos/{owner}/{repo}/tags/{tag}",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "tag"),
-          endpoint.response == "#/responses/Tag",
           request.method == Method.GET,
           request.uri.toString ==
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/tags/release%2Fcandidate",
@@ -573,10 +511,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoListTagProtection,
           endpoint.method == "GET",
-          endpoint.operationId == "repoListTagProtection",
-          endpoint.path == "/repos/{owner}/{repo}/tag_protections",
-          endpoint.parameters.map(_.name) == List("owner", "repo"),
-          endpoint.response == "#/responses/TagProtectionList",
           request.method == Method.GET,
           request.uri.toString ==
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/tag_protections",
@@ -616,10 +550,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoGetTagProtection,
           endpoint.method == "GET",
-          endpoint.operationId == "repoGetTagProtection",
-          endpoint.path == "/repos/{owner}/{repo}/tag_protections/{id}",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "id"),
-          endpoint.response == "#/responses/TagProtection",
           request.method == Method.GET,
           request.uri.toString ==
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/tag_protections/7",
@@ -657,10 +587,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoListBranchProtection,
           endpoint.method == "GET",
-          endpoint.operationId == "repoListBranchProtection",
-          endpoint.path == "/repos/{owner}/{repo}/branch_protections",
-          endpoint.parameters.map(_.name) == List("owner", "repo"),
-          endpoint.response == "#/responses/BranchProtectionList",
           request.method == Method.GET,
           request.uri.toString ==
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/branch_protections",
@@ -701,10 +627,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoGetBranchProtection,
           endpoint.method == "GET",
-          endpoint.operationId == "repoGetBranchProtection",
-          endpoint.path == "/repos/{owner}/{repo}/branch_protections/{name}",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "name"),
-          endpoint.response == "#/responses/BranchProtection",
           request.method == Method.GET,
           request.uri.toString ==
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/branch_protections/release%2F2026",
@@ -740,10 +662,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoListCollaborators,
           endpoint.method == "GET",
-          endpoint.operationId == "repoListCollaborators",
-          endpoint.path == "/repos/{owner}/{repo}/collaborators",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "page", "limit"),
-          endpoint.response == "#/responses/UserList",
           request.method == Method.GET,
           request.uri.toString.contains("/api/v1/repos/worx%20bend/gitea%2Fscala/collaborators?"),
           request.uri.paramsMap.get("page").contains("3"),
@@ -775,10 +693,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoCheckCollaborator,
           endpoint.method == "GET",
-          endpoint.operationId == "repoCheckCollaborator",
-          endpoint.path == "/repos/{owner}/{repo}/collaborators/{collaborator}",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "collaborator"),
-          endpoint.response == "#/responses/empty",
           request.method == Method.GET,
           request.uri.toString ==
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/collaborators/space%20user%2Fslash",
@@ -808,10 +722,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoGetRepoPermissions,
           endpoint.method == "GET",
-          endpoint.operationId == "repoGetRepoPermissions",
-          endpoint.path == "/repos/{owner}/{repo}/collaborators/{collaborator}/permission",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "collaborator"),
-          endpoint.response == "#/responses/RepoCollaboratorPermission",
           request.method == Method.GET,
           request.uri.toString ==
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/collaborators/space%20user%2Fslash/permission",
@@ -859,10 +769,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoListTeams,
           endpoint.method == "GET",
-          endpoint.operationId == "repoListTeams",
-          endpoint.path == "/repos/{owner}/{repo}/teams",
-          endpoint.parameters.map(_.name) == List("owner", "repo"),
-          endpoint.response == "#/responses/TeamList",
           request.method == Method.GET,
           request.uri.toString.contains("/api/v1/repos/worx%20bend/gitea%2Fscala/teams?"),
           request.uri.paramsMap.get("page").contains("4"),
@@ -901,10 +807,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoCheckTeam,
           endpoint.method == "GET",
-          endpoint.operationId == "repoCheckTeam",
-          endpoint.path == "/repos/{owner}/{repo}/teams/{team}",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "team"),
-          endpoint.response == "#/responses/Team",
           request.method == Method.GET,
           request.uri.toString ==
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/teams/space%20team%2Fslash",
@@ -938,10 +840,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
 
         assertTrue(
           endpoint == GiteaEndpoints.repoListReleases,
-          endpoint.operationId == "repoListReleases",
-          endpoint.path == "/repos/{owner}/{repo}/releases",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "draft", "pre-release", "page", "limit"),
-          endpoint.response == "#/responses/ReleaseList",
           request.method == Method.GET,
           request.uri.toString.contains("/api/v1/repos/worx%20bend/gitea%2Fscala/releases?"),
           request.uri.paramsMap.get("page").contains("5"),
@@ -993,10 +891,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
 
         assertTrue(
           endpoint == GiteaEndpoints.repoGetRelease,
-          endpoint.operationId == "repoGetRelease",
-          endpoint.path == "/repos/{owner}/{repo}/releases/{id}",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "id"),
-          endpoint.response == "#/responses/Release",
           request.method == Method.GET,
           request.uri.toString == "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/releases/77"
         )
@@ -1013,10 +907,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoGetLatestRelease,
           endpoint.method == "GET",
-          endpoint.operationId == "repoGetLatestRelease",
-          endpoint.path == "/repos/{owner}/{repo}/releases/latest",
-          endpoint.parameters.map(_.name) == List("owner", "repo"),
-          endpoint.response == "#/responses/Release",
           request.method == Method.GET,
           request.uri.toString ==
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/releases/latest",
@@ -1048,10 +938,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoGetReleaseByTag,
           endpoint.method == "GET",
-          endpoint.operationId == "repoGetReleaseByTag",
-          endpoint.path == "/repos/{owner}/{repo}/releases/tags/{tag}",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "tag"),
-          endpoint.response == "#/responses/Release",
           request.method == Method.GET,
           request.uri.toString ==
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/releases/tags/release%2Fcandidate",
@@ -1096,10 +982,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoListReleaseAttachments,
           endpoint.method == "GET",
-          endpoint.operationId == "repoListReleaseAttachments",
-          endpoint.path == "/repos/{owner}/{repo}/releases/{id}/assets",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "id"),
-          endpoint.response == "#/responses/AttachmentList",
           request.method == Method.GET,
           request.uri.toString == "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/releases/77/assets",
           request.uri.paramsMap.isEmpty,
@@ -1137,10 +1019,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoGetReleaseAttachment,
           endpoint.method == "GET",
-          endpoint.operationId == "repoGetReleaseAttachment",
-          endpoint.path == "/repos/{owner}/{repo}/releases/{id}/assets/{attachment_id}",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "id", "attachment_id"),
-          endpoint.response == "#/responses/Attachment",
           request.method == Method.GET,
           request.uri.toString ==
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/releases/77/assets/901",
@@ -1181,10 +1059,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoGetCombinedStatusByRef,
           endpoint.method == "GET",
-          endpoint.operationId == "repoGetCombinedStatusByRef",
-          endpoint.path == "/repos/{owner}/{repo}/commits/{ref}/status",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "ref", "page", "limit"),
-          endpoint.response == "#/responses/CombinedStatus",
           request.method == Method.GET,
           request.uri.toString.contains(
             "/api/v1/repos/worx%20bend/gitea%2Fscala/commits/feature%2Fslash/status?"
@@ -1284,10 +1158,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoCreateStatus,
           endpoint.method == "POST",
-          endpoint.operationId == "repoCreateStatus",
-          endpoint.path == "/repos/{owner}/{repo}/statuses/{sha}",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "sha", "body"),
-          endpoint.response == "#/responses/CommitStatus",
           request.method == Method.POST,
           request.uri.toString == "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/statuses/abc%2F123",
           request.header("Accept").contains("application/json"),
@@ -1313,10 +1183,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoGetCommitPullRequest,
           endpoint.method == "GET",
-          endpoint.operationId == "repoGetCommitPullRequest",
-          endpoint.path == "/repos/{owner}/{repo}/commits/{sha}/pull",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "sha"),
-          endpoint.response == "#/responses/PullRequest",
           request.method == Method.GET,
           request.uri.toString ==
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/commits/feature%2Fcommit%20abc/pull",
@@ -1348,10 +1214,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoGetSingleCommit,
           endpoint.method == "GET",
-          endpoint.operationId == "repoGetSingleCommit",
-          endpoint.path == "/repos/{owner}/{repo}/git/commits/{sha}",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "sha", "stat", "verification", "files"),
-          endpoint.response == "#/responses/Commit",
           request.method == Method.GET,
           request.uri.toString ==
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/git/commits/feature%2Fcommit%20abc",
@@ -1420,10 +1282,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoDownloadCommitDiffOrPatch,
           endpoint.method == "GET",
-          endpoint.operationId == "repoDownloadCommitDiffOrPatch",
-          endpoint.path == "/repos/{owner}/{repo}/git/commits/{sha}.{diffType}",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "sha", "diffType"),
-          endpoint.response == "#/responses/string",
           request.method == Method.GET,
           request.uri.toString ==
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/git/commits/feature%2Fcommit%20abc.patch",
@@ -1460,10 +1318,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoGetNote,
           endpoint.method == "GET",
-          endpoint.operationId == "repoGetNote",
-          endpoint.path == "/repos/{owner}/{repo}/git/notes/{sha}",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "sha", "verification", "files"),
-          endpoint.response == "#/responses/Note",
           request.method == Method.GET,
           request.uri.toString ==
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/git/notes/feature%2Fcommit%20abc?verification=false&files=true",
@@ -1536,12 +1390,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.getTree,
           endpoint.method == "GET",
-          endpoint.operationId == "GetTree",
-          endpoint.path == "/repos/{owner}/{repo}/git/trees/{sha}",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "sha", "recursive", "page", "per_page"),
-          endpoint.parameters.filter(_.in == "path").forall(_.required),
-          endpoint.parameters.filter(_.in == "query").forall(parameter => !parameter.required),
-          endpoint.response == "#/responses/GitTreeResponse",
           request.method == Method.GET,
           request.uri.toString ==
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/git/trees/feature%2Ftree%20abc?recursive=true&page=2&per_page=50",
@@ -1601,11 +1449,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.getBlob,
           endpoint.method == "GET",
-          endpoint.operationId == "GetBlob",
-          endpoint.path == "/repos/{owner}/{repo}/git/blobs/{sha}",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "sha"),
-          endpoint.parameters.forall(parameter => parameter.in == "path" && parameter.required),
-          endpoint.response == "#/responses/GitBlobResponse",
           request.method == Method.GET,
           request.uri.toString ==
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/git/blobs/blob%2Fabc%20123",
@@ -1647,11 +1490,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.getAnnotatedTag,
           endpoint.method == "GET",
-          endpoint.operationId == "GetAnnotatedTag",
-          endpoint.path == "/repos/{owner}/{repo}/git/tags/{sha}",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "sha"),
-          endpoint.parameters.forall(parameter => parameter.in == "path" && parameter.required),
-          endpoint.response == "#/responses/AnnotatedTag",
           request.method == Method.GET,
           request.uri.toString ==
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/git/tags/tag%2Fabc%20123",
@@ -1689,11 +1527,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoListAllGitRefs,
           endpoint.method == "GET",
-          endpoint.operationId == "repoListAllGitRefs",
-          endpoint.path == "/repos/{owner}/{repo}/git/refs",
-          endpoint.parameters.map(_.name) == List("owner", "repo"),
-          endpoint.parameters.forall(parameter => parameter.in == "path" && parameter.required),
-          endpoint.response == "#/responses/ReferenceList",
           request.method == Method.GET,
           request.uri.toString ==
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/git/refs",
@@ -1728,11 +1561,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoListGitRefs,
           endpoint.method == "GET",
-          endpoint.operationId == "repoListGitRefs",
-          endpoint.path == "/repos/{owner}/{repo}/git/refs/{ref}",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "ref"),
-          endpoint.parameters.forall(parameter => parameter.in == "path" && parameter.required),
-          endpoint.response == "#/responses/ReferenceList",
           request.method == Method.GET,
           request.uri.toString ==
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/git/refs/heads%2Fmain",
@@ -1765,10 +1593,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoGetContentsList,
           endpoint.method == "GET",
-          endpoint.operationId == "repoGetContentsList",
-          endpoint.path == "/repos/{owner}/{repo}/contents",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "ref"),
-          endpoint.response == "#/responses/ContentsListResponse",
           request.method == Method.GET,
           request.uri.toString ==
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/contents",
@@ -1807,10 +1631,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoGetContents,
           endpoint.method == "GET",
-          endpoint.operationId == "repoGetContents",
-          endpoint.path == "/repos/{owner}/{repo}/contents/{filepath}",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "filepath", "ref"),
-          endpoint.response == "#/responses/ContentsResponse",
           request.method == Method.GET,
           request.uri.toString.contains(
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/contents/docs%2Freadme.md?"
@@ -1861,16 +1681,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoGetRawFile,
           endpoint.method == "GET",
-          endpoint.operationId == "repoGetRawFile",
-          endpoint.path == "/repos/{owner}/{repo}/raw/{filepath}",
-          endpoint.parameters.map(parameter => (parameter.name, parameter.in, parameter.required)) ==
-            List(
-              ("owner", "path", true),
-              ("repo", "path", true),
-              ("filepath", "path", true),
-              ("ref", "query", false)
-            ),
-          endpoint.response == "type:file",
           request.method == Method.GET,
           request.uri.toString.contains(
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/raw/docs%2Freadme.md?"
@@ -1906,16 +1716,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoGetRawFileOrLFS,
           endpoint.method == "GET",
-          endpoint.operationId == "repoGetRawFileOrLFS",
-          endpoint.path == "/repos/{owner}/{repo}/media/{filepath}",
-          endpoint.parameters.map(parameter => (parameter.name, parameter.in, parameter.required)) ==
-            List(
-              ("owner", "path", true),
-              ("repo", "path", true),
-              ("filepath", "path", true),
-              ("ref", "query", false)
-            ),
-          endpoint.response == "type:file",
           request.method == Method.GET,
           request.uri.toString.contains(
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/media/docs%2Freadme.md?"
@@ -2013,16 +1813,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoGetArchive,
           endpoint.method == "GET",
-          endpoint.operationId == "repoGetArchive",
-          endpoint.path == "/repos/{owner}/{repo}/archive/{archive}",
-          endpoint.parameters.map(parameter => (parameter.name, parameter.in, parameter.required)) ==
-            List(
-              ("owner", "path", true),
-              ("repo", "path", true),
-              ("archive", "path", true),
-              ("path", "query", false)
-            ),
-          endpoint.response == "description: success",
           request.method == Method.GET,
           request.uri.toString.contains(
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/archive/main.zip"
@@ -2100,11 +1890,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
 
         assertTrue(
           endpoint == GiteaEndpoints.repoListPullRequests,
-          endpoint.operationId == "repoListPullRequests",
-          endpoint.path == "/repos/{owner}/{repo}/pulls",
-          endpoint.parameters.map(_.name) ==
-            List("owner", "repo", "base_branch", "state", "sort", "milestone", "labels", "poster", "page", "limit"),
-          endpoint.response == "#/responses/PullRequestList",
           request.method == Method.GET,
           request.uri.toString.contains("/api/v1/repos/worx%20bend/gitea%2Fscala/pulls?"),
           request.uri.paramsMap.get("base_branch").contains("main"),
@@ -2210,10 +1995,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoListPinnedPullRequests,
           endpoint.method == "GET",
-          endpoint.operationId == "repoListPinnedPullRequests",
-          endpoint.path == "/repos/{owner}/{repo}/pulls/pinned",
-          endpoint.parameters.map(_.name) == List("owner", "repo"),
-          endpoint.response == "#/responses/PullRequestList",
           request.method == Method.GET,
           request.uri.toString == "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/pulls/pinned",
           built.retryable == true
@@ -2288,10 +2069,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoGetPullRequestByBaseHead,
           endpoint.method == "GET",
-          endpoint.operationId == "repoGetPullRequestByBaseHead",
-          endpoint.path == "/repos/{owner}/{repo}/pulls/{base}/{head}",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "base", "head"),
-          endpoint.response == "#/responses/PullRequest",
           request.method == Method.GET,
           request.uri.toString ==
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/pulls/main%20branch/feature%2Fslash",
@@ -2305,10 +2082,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
 
         assertTrue(
           endpoint == GiteaEndpoints.repoGetPullRequest,
-          endpoint.operationId == "repoGetPullRequest",
-          endpoint.path == "/repos/{owner}/{repo}/pulls/{index}",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "index"),
-          endpoint.response == "#/responses/PullRequest",
           request.method == Method.GET,
           request.uri.toString == "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/pulls/88"
         )
@@ -2325,10 +2098,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoPullRequestIsMerged,
           endpoint.method == "GET",
-          endpoint.operationId == "repoPullRequestIsMerged",
-          endpoint.path == "/repos/{owner}/{repo}/pulls/{index}/merge",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "index"),
-          endpoint.response == "204 merged / 404 not merged",
           request.method == Method.GET,
           request.uri.toString == "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/pulls/88/merge",
           request.header("Accept").contains("application/json"),
@@ -2361,10 +2130,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoMergePullRequest,
           endpoint.method == "POST",
-          endpoint.operationId == "repoMergePullRequest",
-          endpoint.path == "/repos/{owner}/{repo}/pulls/{index}/merge",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "index", "body"),
-          endpoint.response == "#/responses/empty",
           request.method == Method.POST,
           request.uri.toString ==
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/pulls/88/merge",
@@ -2590,10 +2355,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoListPullReviews,
           endpoint.method == "GET",
-          endpoint.operationId == "repoListPullReviews",
-          endpoint.path == "/repos/{owner}/{repo}/pulls/{index}/reviews",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "index", "page", "limit"),
-          endpoint.response == "#/responses/PullReviewList",
           request.method == Method.GET,
           request.uri.toString.contains("/api/v1/repos/worx%20bend/gitea%2Fscala/pulls/88/reviews?"),
           request.uri.paramsMap.get("page").contains("3"),
@@ -2630,10 +2391,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           built.endpoint == GiteaEndpoints.repoCreatePullReview,
           built.endpoint.method == "POST",
-          built.endpoint.operationId == "repoCreatePullReview",
-          built.endpoint.path == "/repos/{owner}/{repo}/pulls/{index}/reviews",
-          built.endpoint.parameters.map(_.name) == List("owner", "repo", "index", "body"),
-          built.endpoint.response == "#/responses/PullReview",
           methodOf(built) == Method.POST,
           uriOf(built).toString ==
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/pulls/88/reviews",
@@ -2739,10 +2496,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           built.endpoint == GiteaEndpoints.repoDeletePullReview,
           built.endpoint.method == "DELETE",
-          built.endpoint.operationId == "repoDeletePullReview",
-          built.endpoint.path == "/repos/{owner}/{repo}/pulls/{index}/reviews/{id}",
-          built.endpoint.parameters.map(_.name) == List("owner", "repo", "index", "id"),
-          built.endpoint.response == "#/responses/empty",
           methodOf(built) == Method.DELETE,
           uriOf(built).toString ==
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/pulls/88/reviews/12",
@@ -2766,10 +2519,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoDownloadPullDiffOrPatch,
           endpoint.method == "GET",
-          endpoint.operationId == "repoDownloadPullDiffOrPatch",
-          endpoint.path == "/repos/{owner}/{repo}/pulls/{index}.{diffType}",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "index", "diffType", "binary"),
-          endpoint.response == "#/responses/string",
           request.method == Method.GET,
           request.uri.toString.contains("/api/v1/repos/worx%20bend/gitea%2Fscala/pulls/88.patch?"),
           request.uri.paramsMap.get("binary").contains("true"),
@@ -2791,11 +2540,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoGetPullRequestFiles,
           endpoint.method == "GET",
-          endpoint.operationId == "repoGetPullRequestFiles",
-          endpoint.path == "/repos/{owner}/{repo}/pulls/{index}/files",
-          endpoint.parameters.map(_.name) ==
-            List("owner", "repo", "index", "skip-to", "whitespace", "page", "limit"),
-          endpoint.response == "#/responses/ChangedFileList",
           request.method == Method.GET,
           request.uri.toString.contains("/api/v1/repos/worx%20bend/gitea%2Fscala/pulls/88/files?"),
           request.uri.paramsMap.get("skip-to").contains("src/Main.scala"),
@@ -2819,11 +2563,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoGetPullRequestCommits,
           endpoint.method == "GET",
-          endpoint.operationId == "repoGetPullRequestCommits",
-          endpoint.path == "/repos/{owner}/{repo}/pulls/{index}/commits",
-          endpoint.parameters.map(_.name) ==
-            List("owner", "repo", "index", "page", "limit", "verification", "files"),
-          endpoint.response == "#/responses/CommitList",
           request.method == Method.GET,
           request.uri.toString.contains("/api/v1/repos/worx%20bend/gitea%2Fscala/pulls/88/commits?"),
           request.uri.paramsMap.get("page").contains("4"),
@@ -2866,9 +2605,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
 
         assertTrue(
           endpoint == GiteaEndpoints.issueGetIssue,
-          endpoint.operationId == "issueGetIssue",
-          endpoint.path == "/repos/{owner}/{repo}/issues/{index}",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "index"),
           request.method == Method.GET,
           request.uri.toString == "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/issues/99"
         )
@@ -2881,10 +2617,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.repoListPinnedIssues,
           endpoint.method == "GET",
-          endpoint.operationId == "repoListPinnedIssues",
-          endpoint.path == "/repos/{owner}/{repo}/issues/pinned",
-          endpoint.parameters.map(_.name) == List("owner", "repo"),
-          endpoint.response == "#/responses/IssueList",
           request.method == Method.GET,
           request.uri.toString == "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/issues/pinned",
           built.retryable == true
@@ -2898,10 +2630,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.issueDelete,
           endpoint.method == "DELETE",
-          endpoint.operationId == "issueDelete",
-          endpoint.path == "/repos/{owner}/{repo}/issues/{index}",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "index"),
-          endpoint.response == "#/responses/empty",
           request.method == Method.DELETE,
           request.uri.toString == "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/issues/99",
           request.header("Accept").contains("application/json"),
@@ -2963,10 +2691,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.issueCreateIssue,
           endpoint.method == "POST",
-          endpoint.operationId == "issueCreateIssue",
-          endpoint.path == "/repos/{owner}/{repo}/issues",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "body"),
-          endpoint.response == "#/responses/Issue",
           request.method == Method.POST,
           request.uri.toString == "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/issues",
           request.header("Accept").contains("application/json"),
@@ -2996,10 +2720,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.issueCreateComment,
           endpoint.method == "POST",
-          endpoint.operationId == "issueCreateComment",
-          endpoint.path == "/repos/{owner}/{repo}/issues/{index}/comments",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "index", "body"),
-          endpoint.response == "#/responses/Comment",
           request.method == Method.POST,
           request.uri.toString ==
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/issues/99/comments",
@@ -3249,10 +2969,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.issueEditIssueDeadline,
           endpoint.method == "POST",
-          endpoint.operationId == "issueEditIssueDeadline",
-          endpoint.path == "/repos/{owner}/{repo}/issues/{index}/deadline",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "index", "body"),
-          endpoint.response == "#/responses/IssueDeadline",
           request.method == Method.POST,
           request.uri.toString ==
             "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/issues/99/deadline",
@@ -3552,10 +3268,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           built.endpoint == GiteaEndpoints.userGetStopWatches,
           built.endpoint.method == "GET",
-          built.endpoint.operationId == "userGetStopWatches",
-          built.endpoint.path == "/user/stopwatches",
-          built.endpoint.parameters.map(_.name) == List("page", "limit"),
-          built.endpoint.response == "#/responses/StopWatchList",
           methodOf(built) == Method.GET,
           uriOf(built).toString.contains("/api/v1/user/stopwatches?"),
           uriOf(built).paramsMap.get("page").contains("4"),
@@ -3588,9 +3300,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
 
         assertTrue(
           endpoint == GiteaEndpoints.userSearch,
-          endpoint.operationId == "userSearch",
-          endpoint.path == "/users/search",
-          endpoint.parameters.map(_.name) == List("q", "uid", "page", "limit"),
           request.method == Method.GET,
           request.uri.toString.contains("/api/v1/users/search?"),
           request.uri.paramsMap.get("q").contains("space user"),
@@ -3614,11 +3323,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
 
         assertTrue(
           endpoint == GiteaEndpoints.notifyGetList,
-          endpoint.operationId == "notifyGetList",
-          endpoint.path == "/notifications",
-          endpoint.parameters.map(_.name) ==
-            List("all", "status-types", "subject-type", "since", "before", "page", "limit"),
-          endpoint.response == "#/responses/NotificationThreadList",
           request.method == Method.GET,
           request.uri.toString.contains("/api/v1/notifications?"),
           request.uri.paramsMap.get("all").contains("true"),
@@ -3680,10 +3384,6 @@ object GiteaRequestsSpec extends ZIOSpecDefault:
         assertTrue(
           endpoint == GiteaEndpoints.issueEditIssue,
           endpoint.method == "PATCH",
-          endpoint.operationId == "issueEditIssue",
-          endpoint.path == "/repos/{owner}/{repo}/issues/{index}",
-          endpoint.parameters.map(_.name) == List("owner", "repo", "index", "body"),
-          endpoint.response == "#/responses/Issue",
           request.method == Method.PATCH,
           request.uri.toString == "https://gitea.example/root/api/v1/repos/worx%20bend/gitea%2Fscala/issues/99",
           request.header("Accept").contains("application/json"),

--- a/client/test/src/io/worxbend/gitea4s/internal/GiteaRequestExecutorSpec.scala
+++ b/client/test/src/io/worxbend/gitea4s/internal/GiteaRequestExecutorSpec.scala
@@ -181,6 +181,19 @@ object GiteaRequestExecutorSpec extends ZIOSpecDefault:
           events <- ref.get
         yield assertTrue(events.size == 1, events.head.attempts == 2, events.head.retried)
       } @@ TestAspect.withLiveClock,
+      test("an observer that never finishes cannot withhold the result") {
+        // `catchAllCause` handles an observer that fails, not one that hangs.
+        // The recommended escape hatch in the scaladoc — offer to a `Queue` —
+        // is precisely what suspends forever once that queue is full, so this
+        // is the shape a well-intentioned observer actually fails in.
+        val stalling = new GiteaObserver:
+          def onComplete(event: RequestEvent): zio.UIO[Unit] = ZIO.never
+
+        GiteaRequestExecutor(respondWith(ok(user)), maxRetries = 0, stalling)
+          .send(GiteaRequests.currentUser(config))
+          .timeout(zio.Duration.fromSeconds(30))
+          .map(result => assertTrue(result.exists(_.login.contains("alice"))))
+      } @@ TestAspect.withLiveClock,
       test("emits an event when the call dies with a defect") {
         // `Cause.failureOption` sees only typed failures, so a defect used to
         // produce no event at all and the success and failure counts stopped

--- a/client/test/src/io/worxbend/gitea4s/internal/GiteaRequestExecutorSpec.scala
+++ b/client/test/src/io/worxbend/gitea4s/internal/GiteaRequestExecutorSpec.scala
@@ -86,11 +86,43 @@ object GiteaRequestExecutorSpec extends ZIOSpecDefault:
       test("gives up once the retry budget is spent instead of retrying forever") {
         val backend = respondWith(rateLimited("retry-after" -> "0"))
 
-        GiteaRequestExecutor(backend, maxRetries = 2)
-          .send(GiteaRequests.currentUser(config))
-          .either
-          .map(result => assertTrue(result.isLeft))
+        // `result.isLeft` alone would hold with zero retries too — it passed
+        // when `sendWithRetries` was replaced by `sendOnce`. The attempt count
+        // is what actually says the budget was spent rather than skipped.
+        for
+          ref <- Ref.make(Chunk.empty[RequestEvent])
+          result <- GiteaRequestExecutor(backend, maxRetries = 2, recording(ref))
+            .send(GiteaRequests.currentUser(config))
+            .either
+          events <- ref.get
+        yield assertTrue(result.isLeft, events.head.attempts == 3)
       } @@ TestAspect.withLiveClock,
+      test("backs off further after each failed attempt") {
+        // Nothing else in this suite reaches `jitteredBackoff` with attempt > 1,
+        // so the doubling was unexercised: replacing the shift with a constant
+        // left the whole build green.
+        //
+        // The boundary is chosen to sit outside the 0.8-1.2 jitter band rather
+        // than comparing one wait against the next, which would be flaky.
+        // Doubling from 100ms gives waits of 100/200/400, so the fourth attempt
+        // cannot be sent before 80+160+320 = 560ms. A flat 100ms would have
+        // sent it by 360ms at the latest. At 500ms, exactly three attempts have
+        // been made if and only if the delay is growing.
+        for
+          sent <- Ref.make(0)
+          backend = BackendStub[Task](new RIOMonadAsyncError[Any]).whenAnyRequest.thenRespondF { _ =>
+            sent.update(_ + 1).as(ResponseStub.adjust("", StatusCode.ServiceUnavailable))
+          }
+          fiber <- GiteaRequestExecutor(backend, maxRetries = 3)
+            .send(GiteaRequests.currentUser(config))
+            .either
+            .fork
+          _ <- TestClock.adjust(Duration.fromMillis(500))
+          attempts <- sent.get
+          _ <- TestClock.adjust(Duration.fromSeconds(5))
+          _ <- fiber.join
+        yield assertTrue(attempts == 3)
+      },
       test("does not retry an error that cannot be retried") {
         val backend = respondWith(ResponseStub.adjust("""{"message":"nope"}""", StatusCode.NotFound))
 

--- a/client/test/src/io/worxbend/gitea4s/observability/GiteaObserverSpec.scala
+++ b/client/test/src/io/worxbend/gitea4s/observability/GiteaObserverSpec.scala
@@ -50,6 +50,38 @@ object GiteaObserverSpec extends ZIOSpecDefault:
             case _ => false
         )
       },
+      test("the logging observer names the wrapped cause and the status") {
+        // `getClass.getSimpleName` reported the bare word `TransportError` for
+        // DNS failure, connection refused, TLS errors, read timeouts and the
+        // executor's own exhausted budget alike — and never logged the status
+        // it was already carrying, so a 502 and a 403 read identically.
+        val lines = scala.collection.mutable.ListBuffer.empty[String]
+        val capture = new zio.ZLogger[String, Unit]:
+          def apply(
+              trace: zio.Trace,
+              fiberId: zio.FiberId,
+              level: zio.LogLevel,
+              message: () => String,
+              cause: zio.Cause[Any],
+              context: zio.FiberRefs,
+              spans: List[zio.LogSpan],
+              annotations: Map[String, String]
+          ): Unit = { val _ = lines.append(message()) }
+
+        val backend = stub("""{"message":"boom"}""", StatusCode.BadGateway)
+
+        GiteaRequestExecutor(backend, maxRetries = 0, GiteaObserver.logging)
+          .send(GiteaRequests.currentUser(config))
+          .either
+          .map { _ =>
+            val logged = lines.mkString("\n")
+            assertTrue(
+              logged.contains("ServerError(502)"),
+              logged.contains("status=502")
+            )
+          }
+          .provideLayer(zio.Runtime.removeDefaultLoggers ++ zio.Runtime.addLogger(capture))
+      },
       test("the default noop observer records nothing") {
         val backend = stub("""{"id":1,"login":"alice"}""", StatusCode.Ok)
         for

--- a/core/src/io/worxbend/gitea4s/error/GiteaError.scala
+++ b/core/src/io/worxbend/gitea4s/error/GiteaError.scala
@@ -9,7 +9,23 @@ import java.time.Instant
   * `RateLimited` carries the reset time when Gitea sends one; `DecodeError` keeps
   * the raw body; and `TransportError` preserves the underlying cause.
   */
-sealed trait GiteaError extends Product with Serializable
+sealed trait GiteaError extends Product with Serializable:
+  /** What went wrong, in one line, for every case.
+    *
+    * Nine of the thirteen cases already carried a `message`, but there was no
+    * way to ask a `GiteaError` for one without enumerating all thirteen — so
+    * the commonest thing a caller wants to do with an error, log it or show
+    * it, required a total match that has to be revisited whenever a case is
+    * added. The four that carry no message field derive one.
+    *
+    * Deliberately not a constructor parameter anywhere: adding a field to a
+    * published case class would rewrite its `apply`, `copy` and `unapply`.
+    * This adds a method and takes nothing away.
+    *
+    * For the full server response, match on the case and read `body`; this is
+    * the summary, not a replacement for it.
+    */
+  def message: String
 
 object GiteaError:
   final case class BadRequest(message: String, body: String) extends GiteaError
@@ -21,7 +37,15 @@ object GiteaError:
   final case class PreconditionFailed(message: String, body: String) extends GiteaError
   final case class UnprocessableEntity(message: String, body: String) extends GiteaError
   final case class Locked(message: String, body: String) extends GiteaError
-  final case class RateLimited(resetAt: Option[Instant], body: String) extends GiteaError
-  final case class ServerError(status: Int, body: String) extends GiteaError
+  final case class RateLimited(resetAt: Option[Instant], body: String) extends GiteaError:
+    def message: String = resetAt.fold("Rate limited")(instant => s"Rate limited until $instant")
+
+  final case class ServerError(status: Int, body: String) extends GiteaError:
+    def message: String = s"HTTP $status"
+
   final case class DecodeError(message: String, body: String) extends GiteaError
-  final case class TransportError(cause: Throwable) extends GiteaError
+
+  final case class TransportError(cause: Throwable) extends GiteaError:
+    // A `Throwable` may have a null message, and `getClass.getName` is more use
+    // to a reader than the word "null".
+    def message: String = Option(cause.getMessage).getOrElse(cause.toString)

--- a/core/src/io/worxbend/gitea4s/model/CommitStatus.scala
+++ b/core/src/io/worxbend/gitea4s/model/CommitStatus.scala
@@ -13,13 +13,14 @@ enum CommitStatusState(val jsonValue: String):
   case Skipped extends CommitStatusState("skipped")
 
 object CommitStatusState:
-  private val byJsonValue = CommitStatusState.values.map(state => state.jsonValue -> state).toMap
+  private val json = JsonValueLookup(CommitStatusState.values, "commit status state", _.jsonValue)
 
-  def fromString(value: String): Either[String, CommitStatusState] =
-    byJsonValue.get(value).toRight(s"Unknown commit status state: $value")
+  def fromString(value: String): Either[String, CommitStatusState] = json.fromString(value)
 
-  given JsonCodec[CommitStatusState] =
-    summon[JsonCodec[String]].transformOrFail(fromString, _.jsonValue)
+  given JsonCodec[CommitStatusState] = json.codec
+
+  /** Unknown values read as `None`; see [[JsonValueLookup.lenientOptionDecoder]]. */
+  given JsonDecoder[Option[CommitStatusState]] = json.lenientOptionDecoder
 
 final case class CommitStatus(
     context: Option[String] = None,

--- a/core/src/io/worxbend/gitea4s/model/Enums.scala
+++ b/core/src/io/worxbend/gitea4s/model/Enums.scala
@@ -7,26 +7,28 @@ enum IssueState(val jsonValue: String):
   case Closed extends IssueState("closed")
 
 object IssueState:
-  private val byJsonValue = IssueState.values.map(state => state.jsonValue -> state).toMap
+  private val json = JsonValueLookup(IssueState.values, "issue state", _.jsonValue)
 
-  def fromString(value: String): Either[String, IssueState] =
-    byJsonValue.get(value).toRight(s"Unknown issue state: $value")
+  def fromString(value: String): Either[String, IssueState] = json.fromString(value)
 
-  given JsonCodec[IssueState] =
-    summon[JsonCodec[String]].transformOrFail(fromString, _.jsonValue)
+  given JsonCodec[IssueState] = json.codec
+
+  /** Unknown values read as `None`; see [[JsonValueLookup.lenientOptionDecoder]]. */
+  given JsonDecoder[Option[IssueState]] = json.lenientOptionDecoder
 
 enum ObjectFormatName(val jsonValue: String):
   case Sha1 extends ObjectFormatName("sha1")
   case Sha256 extends ObjectFormatName("sha256")
 
 object ObjectFormatName:
-  private val byJsonValue = ObjectFormatName.values.map(format => format.jsonValue -> format).toMap
+  private val json = JsonValueLookup(ObjectFormatName.values, "object format name", _.jsonValue)
 
-  def fromString(value: String): Either[String, ObjectFormatName] =
-    byJsonValue.get(value).toRight(s"Unknown object format name: $value")
+  def fromString(value: String): Either[String, ObjectFormatName] = json.fromString(value)
 
-  given JsonCodec[ObjectFormatName] =
-    summon[JsonCodec[String]].transformOrFail(fromString, _.jsonValue)
+  given JsonCodec[ObjectFormatName] = json.codec
+
+  /** Unknown values read as `None`; see [[JsonValueLookup.lenientOptionDecoder]]. */
+  given JsonDecoder[Option[ObjectFormatName]] = json.lenientOptionDecoder
 
 enum TeamPermission(val jsonValue: String):
   case None extends TeamPermission("none")
@@ -36,13 +38,14 @@ enum TeamPermission(val jsonValue: String):
   case Owner extends TeamPermission("owner")
 
 object TeamPermission:
-  private val byJsonValue = TeamPermission.values.map(permission => permission.jsonValue -> permission).toMap
+  private val json = JsonValueLookup(TeamPermission.values, "team permission", _.jsonValue)
 
-  def fromString(value: String): Either[String, TeamPermission] =
-    byJsonValue.get(value).toRight(s"Unknown team permission: $value")
+  def fromString(value: String): Either[String, TeamPermission] = json.fromString(value)
 
-  given JsonCodec[TeamPermission] =
-    summon[JsonCodec[String]].transformOrFail(fromString, _.jsonValue)
+  given JsonCodec[TeamPermission] = json.codec
+
+  /** Unknown values read as `None`; see [[JsonValueLookup.lenientOptionDecoder]]. */
+  given JsonDecoder[Option[TeamPermission]] = json.lenientOptionDecoder
 
 enum NotificationSubjectState(val jsonValue: String):
   case Open extends NotificationSubjectState("open")
@@ -50,13 +53,14 @@ enum NotificationSubjectState(val jsonValue: String):
   case Merged extends NotificationSubjectState("merged")
 
 object NotificationSubjectState:
-  private val byJsonValue = NotificationSubjectState.values.map(state => state.jsonValue -> state).toMap
+  private val json = JsonValueLookup(NotificationSubjectState.values, "notification subject state", _.jsonValue)
 
-  def fromString(value: String): Either[String, NotificationSubjectState] =
-    byJsonValue.get(value).toRight(s"Unknown notification subject state: $value")
+  def fromString(value: String): Either[String, NotificationSubjectState] = json.fromString(value)
 
-  given JsonCodec[NotificationSubjectState] =
-    summon[JsonCodec[String]].transformOrFail(fromString, _.jsonValue)
+  given JsonCodec[NotificationSubjectState] = json.codec
+
+  /** Unknown values read as `None`; see [[JsonValueLookup.lenientOptionDecoder]]. */
+  given JsonDecoder[Option[NotificationSubjectState]] = json.lenientOptionDecoder
 
 enum NotificationSubjectType(val jsonValue: String, val queryValue: String):
   case Issue extends NotificationSubjectType("Issue", "issue")
@@ -65,13 +69,14 @@ enum NotificationSubjectType(val jsonValue: String, val queryValue: String):
   case Repository extends NotificationSubjectType("Repository", "repository")
 
 object NotificationSubjectType:
-  private val byJsonValue = NotificationSubjectType.values.map(subjectType => subjectType.jsonValue -> subjectType).toMap
+  private val json = JsonValueLookup(NotificationSubjectType.values, "notification subject type", _.jsonValue)
 
-  def fromString(value: String): Either[String, NotificationSubjectType] =
-    byJsonValue.get(value).toRight(s"Unknown notification subject type: $value")
+  def fromString(value: String): Either[String, NotificationSubjectType] = json.fromString(value)
 
-  given JsonCodec[NotificationSubjectType] =
-    summon[JsonCodec[String]].transformOrFail(fromString, _.jsonValue)
+  given JsonCodec[NotificationSubjectType] = json.codec
+
+  /** Unknown values read as `None`; see [[JsonValueLookup.lenientOptionDecoder]]. */
+  given JsonDecoder[Option[NotificationSubjectType]] = json.lenientOptionDecoder
 
 enum PullReviewState(val jsonValue: String):
   case Approved extends PullReviewState("APPROVED")
@@ -81,13 +86,14 @@ enum PullReviewState(val jsonValue: String):
   case RequestReview extends PullReviewState("REQUEST_REVIEW")
 
 object PullReviewState:
-  private val byJsonValue = PullReviewState.values.map(state => state.jsonValue -> state).toMap
+  private val json = JsonValueLookup(PullReviewState.values, "pull review state", _.jsonValue)
 
-  def fromString(value: String): Either[String, PullReviewState] =
-    byJsonValue.get(value).toRight(s"Unknown pull review state: $value")
+  def fromString(value: String): Either[String, PullReviewState] = json.fromString(value)
 
-  given JsonCodec[PullReviewState] =
-    summon[JsonCodec[String]].transformOrFail(fromString, _.jsonValue)
+  given JsonCodec[PullReviewState] = json.codec
+
+  /** Unknown values read as `None`; see [[JsonValueLookup.lenientOptionDecoder]]. */
+  given JsonDecoder[Option[PullReviewState]] = json.lenientOptionDecoder
 
 enum MergePullRequestMethod(val jsonValue: String):
   case Merge extends MergePullRequestMethod("merge")
@@ -98,10 +104,11 @@ enum MergePullRequestMethod(val jsonValue: String):
   case ManuallyMerged extends MergePullRequestMethod("manually-merged")
 
 object MergePullRequestMethod:
-  private val byJsonValue = MergePullRequestMethod.values.map(method => method.jsonValue -> method).toMap
+  private val json = JsonValueLookup(MergePullRequestMethod.values, "merge pull request method", _.jsonValue)
 
-  def fromString(value: String): Either[String, MergePullRequestMethod] =
-    byJsonValue.get(value).toRight(s"Unknown merge pull request method: $value")
+  def fromString(value: String): Either[String, MergePullRequestMethod] = json.fromString(value)
 
-  given JsonCodec[MergePullRequestMethod] =
-    summon[JsonCodec[String]].transformOrFail(fromString, _.jsonValue)
+  given JsonCodec[MergePullRequestMethod] = json.codec
+
+  /** Unknown values read as `None`; see [[JsonValueLookup.lenientOptionDecoder]]. */
+  given JsonDecoder[Option[MergePullRequestMethod]] = json.lenientOptionDecoder

--- a/core/src/io/worxbend/gitea4s/model/JsonValueLookup.scala
+++ b/core/src/io/worxbend/gitea4s/model/JsonValueLookup.scala
@@ -1,0 +1,56 @@
+package io.worxbend.gitea4s.model
+
+import zio.json.*
+
+/** The wire-value mapping every enum in this package needs, written once.
+  *
+  * Each companion previously repeated the same three declarations — a
+  * `byJsonValue` map, a `fromString`, and a `given JsonCodec` built by
+  * `transformOrFail` — differing only in the enum and the phrasing of the
+  * error. Adding an enum meant copying them again, and the lenient decoder
+  * below would otherwise have had to be copied eight times too.
+  *
+  * `private[model]` keeps it out of the Scala-visible API: nothing outside this
+  * package can name it. It is still reachable in bytecode — Scala compiles
+  * qualified-private to public — so it does appear in `api-snapshot/core.txt`,
+  * as `ownedClient` and friends already do in the backend modules. It is not
+  * part of the supported surface and carries no compatibility promise.
+  */
+private[model] final class JsonValueLookup[A](
+    values: Array[A],
+    label: String,
+    jsonValue: A => String
+):
+  private val byJsonValue: Map[String, A] =
+    values.map(value => jsonValue(value) -> value).toMap
+
+  /** Strict: an unrecognised value is an error.
+    *
+    * This is what write positions need — sending a value the server will
+    * reject is worth failing on, loudly and locally.
+    */
+  def fromString(value: String): Either[String, A] =
+    byJsonValue.get(value).toRight(s"Unknown $label: $value")
+
+  def codec: JsonCodec[A] =
+    summon[JsonCodec[String]].transformOrFail(fromString, jsonValue)
+
+  /** Lenient: an unrecognised value decodes as `None` rather than failing.
+    *
+    * Gitea adds enum members between minor versions, and these fields are read
+    * positions on responses. Without this, one unrecognised string anywhere in
+    * a page fails the decode of the *whole* page — `GiteaResponseMapper`
+    * decodes a page as a single `Chunk[A]` — so the caller loses every other
+    * item on it, and the `ZStream` from `Pagination` then fails, losing every
+    * page after it too. Trading one unreadable field for a whole collection is
+    * the wrong way round when the server is free to evolve independently.
+    *
+    * `null` and an absent field still decode as `None`, exactly as before; the
+    * only behaviour that changes is a present-but-unknown string.
+    *
+    * Resolution note: this is more specific than zio-json's generic
+    * `JsonDecoder.option`, so placing it in a companion makes it the instance
+    * chosen for that enum's `Option` fields.
+    */
+  def lenientOptionDecoder: JsonDecoder[Option[A]] =
+    JsonDecoder.option[String].map(_.flatMap(byJsonValue.get))

--- a/core/test/src/io/worxbend/gitea4s/model/ApiReferenceSpec.scala
+++ b/core/test/src/io/worxbend/gitea4s/model/ApiReferenceSpec.scala
@@ -3,13 +3,23 @@ package io.worxbend.gitea4s.model
 import zio.json.*
 import zio.test.*
 
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path, Paths}
+
 object ApiReferenceSpec extends ZIOSpecDefault:
   def spec =
     suite("ApiReference")(
-      test("records the local Gitea API contract") {
+      test("records the version of the contract actually vendored here") {
+        // Previously this compared the constant against a retyped copy of
+        // itself, so refreshing `plugin-redoc-2.yaml` to a newer Gitea would
+        // ship a banner naming the old version with the build still green.
+        // Reading the spec is the only way this assertion can fail for the
+        // reason it exists.
         assertTrue(
-          ApiReference.gitea1262.version == "1.26.2",
-          ApiReference.gitea1262.document == "plugin-redoc-2.yaml"
+          ApiReference.gitea1262.version == swaggerVersion(),
+          ApiReference.gitea1262.document == "plugin-redoc-2.yaml",
+          // The document it names must be the one that was read.
+          Files.isRegularFile(swaggerPath())
         )
       },
       test("round-trips through zio-json") {
@@ -18,3 +28,22 @@ object ApiReferenceSpec extends ZIOSpecDefault:
         assertTrue(decoded == Right(ApiReference.gitea1262))
       }
     )
+
+  /** The `info.version` of the vendored OpenAPI document. */
+  private def swaggerVersion(): String =
+    val lines = Files.readString(swaggerPath(), StandardCharsets.UTF_8).linesIterator
+    lines
+      .map(_.trim)
+      .collectFirst { case line if line.startsWith("version:") => line.stripPrefix("version:").trim }
+      .getOrElse(throw IllegalStateException("plugin-redoc-2.yaml declares no version"))
+
+  /** Walks up from the working directory, as the other spec readers do, so this
+    * runs from any module.
+    */
+  private def swaggerPath(): Path =
+    Iterator
+      .iterate(Paths.get("").toAbsolutePath)(_.getParent)
+      .takeWhile(_ != null)
+      .map(_.resolve("plugin-redoc-2.yaml"))
+      .find(Files.isRegularFile(_))
+      .getOrElse(Paths.get("plugin-redoc-2.yaml").toAbsolutePath)

--- a/core/test/src/io/worxbend/gitea4s/model/EnumDriftSpec.scala
+++ b/core/test/src/io/worxbend/gitea4s/model/EnumDriftSpec.scala
@@ -1,0 +1,68 @@
+package io.worxbend.gitea4s.model
+
+import zio.Chunk
+import zio.json.*
+import zio.test.*
+
+/** Forward compatibility with a Gitea that has learned a new enum value.
+  *
+  * Gitea adds enum members between minor versions. Before these tests, one
+  * unrecognised string anywhere in a page failed the decode of the entire page
+  * — `GiteaResponseMapper` decodes a page as a single `Chunk[A]` — so a caller
+  * lost every other item on it, and the `ZStream` above it then failed, losing
+  * every later page too.
+  */
+object EnumDriftSpec extends ZIOSpecDefault:
+  def spec =
+    suite("unknown enum values")(
+      test("a page survives an item carrying an unknown value") {
+        // The valid first thread is the point: it used to be discarded along
+        // with the one the client could not fully understand.
+        val page =
+          """[{"id":1,"unread":true,"subject":{"title":"a","state":"open"}},
+             {"id":2,"unread":false,"subject":{"title":"b","state":"quantum-superposition"}}]"""
+
+        page.fromJson[Chunk[NotificationThread]] match
+          case Left(error) => assertNever(s"page failed to decode: $error")
+          case Right(threads) =>
+            assertTrue(
+              threads.size == 2,
+              threads.head.subject.flatMap(_.state).contains(NotificationSubjectState.Open),
+              // Unreadable, so absent — never a wrong value, and never fatal.
+              threads(1).subject.flatMap(_.state).isEmpty,
+              // Everything the client *can* read is still read.
+              threads(1).subject.flatMap(_.title).contains("b")
+            )
+      },
+      test("each read-position enum tolerates an unknown value") {
+        val issue = """{"id":1,"state":"archived"}""".fromJson[Issue]
+        val review = """{"id":1,"state":"RESCINDED"}""".fromJson[PullReview]
+        val team = """{"id":1,"permission":"superuser"}""".fromJson[Team]
+        val status = """{"id":1,"status":"cancelled"}""".fromJson[CommitStatus]
+        val repo = """{"id":1,"object_format_name":"sha512"}""".fromJson[Repository]
+
+        assertTrue(
+          issue.map(_.state) == Right(None),
+          review.map(_.state) == Right(None),
+          team.map(_.permission) == Right(None),
+          status.map(_.state) == Right(None),
+          repo.map(_.objectFormatName) == Right(None)
+        )
+      },
+      test("a known value still decodes, and absence is still absence") {
+        assertTrue(
+          """{"id":1,"state":"closed"}""".fromJson[Issue].map(_.state) == Right(Some(IssueState.Closed)),
+          """{"id":1}""".fromJson[Issue].map(_.state) == Right(None),
+          """{"id":1,"state":null}""".fromJson[Issue].map(_.state) == Right(None)
+        )
+      },
+      test("write positions stay strict") {
+        // Sending a value the server will reject is worth failing on. These are
+        // request bodies, so leniency would only hide a caller's mistake.
+        assertTrue(
+          MergePullRequestMethod.fromString("teleport").isLeft,
+          IssueState.fromString("archived").isLeft,
+          """{"Do":"teleport"}""".fromJson[MergePullRequestOption].isLeft
+        )
+      }
+    )

--- a/examples/src/io/worxbend/gitea4s/examples/ExampleApp.scala
+++ b/examples/src/io/worxbend/gitea4s/examples/ExampleApp.scala
@@ -1,0 +1,20 @@
+package io.worxbend.gitea4s.examples
+
+import zio.{Runtime, ZIOAppDefault, ZLayer}
+
+/** The entry point every example extends.
+  *
+  * `ExampleSupport.runExample` prints a readable one-line failure and then
+  * re-fails, which is what keeps the process exit code non-zero. But
+  * `GiteaError` is not a `Throwable`, so `ZIOAppDefault`'s default handler
+  * logged the same failure a second time as a multi-line `cause=` block with a
+  * stack trace pointing into `ExampleSupport`. Every failure was reported
+  * twice, and the second report was the less useful one.
+  *
+  * Removing the default loggers keeps the friendly line and the exit code and
+  * drops the duplicate. It is deliberately not `.as(ExitCode.failure)`: that
+  * would silence the failure channel as well, and a non-zero exit is exactly
+  * what a CI step running these examples needs.
+  */
+private[examples] trait ExampleApp extends ZIOAppDefault:
+  override val bootstrap: ZLayer[Any, Nothing, Unit] = Runtime.removeDefaultLoggers

--- a/examples/src/io/worxbend/gitea4s/examples/ExampleSupport.scala
+++ b/examples/src/io/worxbend/gitea4s/examples/ExampleSupport.scala
@@ -1,14 +1,60 @@
 package io.worxbend.gitea4s.examples
 
+import io.worxbend.gitea4s.backend.zio.ZioGiteaBackend
 import io.worxbend.gitea4s.error.GiteaError
 import io.worxbend.gitea4s.model.{ApiReference, Branch, NotificationThread, PullRequest, Release, Repository, Tag, User}
-import io.worxbend.gitea4s.{GiteaConfig, GiteaConfigError}
+import io.worxbend.gitea4s.{GiteaClient, GiteaConfig, GiteaConfigError}
+import zio.{Console, ZIO}
 
 private[examples] object ExampleSupport:
   val referenceLine: String = s"gitea4s targets Gitea API ${ApiReference.gitea1262.version}"
 
   val credentialsHint: String =
     "Set GITEA_URL with GITEA_TOKEN or GITEA_USERNAME/GITEA_PASSWORD to run the live example."
+
+  /** Runs one example against a live server, or explains why it cannot.
+    *
+    * Every main here had its own copy of the same twenty lines: match on the
+    * config, print the reference line on all three branches, build the backend
+    * layer, fold the failure into a message and re-fail, then print the result.
+    * That ceremony was most of each file, which buried the two or three lines
+    * that actually demonstrate the library — and these examples exist to be
+    * read.
+    *
+    * `use` returns the lines to print, so an example describes *what* it wants
+    * shown and never repeats *how* to show it. `hints` are printed instead when
+    * no credentials are configured, so each example can say which extra
+    * environment variables it needs.
+    */
+  def runExample(failureLabel: String, hints: String*)(
+      use: GiteaClient => ZIO[Any, GiteaError, Seq[String]]
+  ): ZIO[Any, Any, Unit] =
+    liveConfigFromEnv match
+      case Right(None) =>
+        printLines(referenceLine +: hints.prepended(credentialsHint))
+
+      case Left(error) =>
+        Console.printLine(referenceLine) *>
+          Console.printLineError(s"Cannot read live Gitea config: ${error.message}") *>
+          ZIO.fail(error)
+
+      case Right(Some(config)) =>
+        Console.printLine(referenceLine) *>
+          ZIO
+            .serviceWithZIO[GiteaClient](use)
+            .provideLayer(ZioGiteaBackend.configured(config))
+            .foldZIO(
+              error =>
+                Console.printLineError(s"$failureLabel failed: ${describeFailure(error)}") *> ZIO.fail(error),
+              printLines
+            )
+
+  /** Reads an environment variable that an example needs, ignoring blanks. */
+  def optionalEnv(name: String): Option[String] =
+    nonBlank(sys.env.toMap, name)
+
+  private def printLines(lines: Seq[String]): ZIO[Any, Nothing, Unit] =
+    ZIO.foreachDiscard(lines)(line => Console.printLine(line).orDie)
 
   def liveConfigFromEnv: Either[GiteaConfigError, Option[GiteaConfig]] =
     val env = sys.env.toMap

--- a/examples/src/io/worxbend/gitea4s/examples/ExampleSupport.scala
+++ b/examples/src/io/worxbend/gitea4s/examples/ExampleSupport.scala
@@ -64,7 +64,7 @@ private[examples] object ExampleSupport:
 
   def describeFailure(error: GiteaError | Throwable): String =
     error match
-      case giteaError: GiteaError => describe(giteaError)
+      case giteaError: GiteaError => s"${giteaError.message}${detail(giteaError)}"
       case throwable: Throwable => s"backend initialization failed: ${throwable.getMessage}"
 
   def repositoryName(repository: Repository): String =
@@ -136,21 +136,19 @@ private[examples] object ExampleSupport:
   private def nonBlank(env: Map[String, String], name: String): Option[String] =
     env.get(name).map(_.trim).filter(_.nonEmpty)
 
-  private def describe(error: GiteaError): String =
+  /** What a `ServerError` says beyond its status.
+    *
+    * `GiteaError.message` renders a 5xx as `HTTP 500`, which is all it can say
+    * without inventing one — the status is the whole message. The body is the
+    * only diagnostic such a response carries, so a short prefix of it is worth
+    * showing rather than discarding.
+    */
+  private def detail(error: GiteaError): String =
     error match
-      case GiteaError.BadRequest(message, _) => s"bad request: $message"
-      case GiteaError.Unauthorized(message, _) => s"unauthorized: $message"
-      case GiteaError.Forbidden(message, _) => s"forbidden: $message"
-      case GiteaError.NotFound(message, _) => s"not found: $message"
-      case GiteaError.MethodNotAllowed(message, _) => s"method not allowed: $message"
-      case GiteaError.Conflict(message, _) => s"conflict: $message"
-      case GiteaError.PreconditionFailed(message, _) => s"precondition failed: $message"
-      case GiteaError.UnprocessableEntity(message, _) => s"unprocessable entity: $message"
-      case GiteaError.Locked(message, _) => s"locked: $message"
-      case GiteaError.RateLimited(resetAt, _) => s"rate limited; reset at ${resetAt.fold("unknown")(_.toString)}"
-      case GiteaError.ServerError(status, _) => s"server error: HTTP $status"
-      case GiteaError.DecodeError(message, _) => s"decode error: $message"
-      case GiteaError.TransportError(cause) => s"transport error: ${cause.getMessage}"
+      case GiteaError.ServerError(_, body) =>
+        val text = body.trim
+        if text.isEmpty then "" else s": ${text.take(200)}"
+      case _ => ""
 
   private def shortSha(value: String): String =
     value.take(12)

--- a/examples/src/io/worxbend/gitea4s/examples/ListBranchesAndTags.scala
+++ b/examples/src/io/worxbend/gitea4s/examples/ListBranchesAndTags.scala
@@ -1,61 +1,30 @@
 package io.worxbend.gitea4s.examples
 
-import io.worxbend.gitea4s.GiteaClient
-import io.worxbend.gitea4s.backend.zio.ZioGiteaBackend
-import zio.{Console, ZIO, ZIOAppDefault}
+import zio.{ZIO, ZIOAppDefault}
 
 object ListBranchesAndTags extends ZIOAppDefault:
   private val ownerEnv = "GITEA_OWNER"
   private val repoEnv = "GITEA_REPO"
 
   def run =
-    ExampleSupport.liveConfigFromEnv match
-      case Right(None) =>
-        Console.printLine(ExampleSupport.referenceLine) *>
-          Console.printLine(ExampleSupport.credentialsHint) *>
-          Console.printLine(repositoryHint)
-      case Left(error) =>
-        Console.printLine(ExampleSupport.referenceLine) *>
-          Console.printLineError(s"Cannot read live Gitea config: ${error.message}") *>
-          ZIO.fail(error)
-      case Right(Some(config)) =>
-        repositoryFromEnv match
-          case None =>
-            Console.printLine(ExampleSupport.referenceLine) *>
-              Console.printLine(repositoryHint)
-          case Some((owner, repo)) =>
-            val program =
-              ZIO.serviceWithZIO[GiteaClient] { client =>
-                for
-                  branches <- client.repos.branches(owner, repo).take(25).runCollect
-                  tags <- client.repos.tags(owner, repo).take(25).runCollect
-                yield (branches, tags)
-              }
-
-            Console.printLine(ExampleSupport.referenceLine) *>
-              program
-                .provideLayer(ZioGiteaBackend.configured(config))
-                .foldZIO(
-                  error => Console.printLineError(s"Listing branches and tags failed: ${ExampleSupport.describeFailure(error)}") *> ZIO.fail(error),
-                  (branches, tags) =>
-                    Console.printLine(s"Branches for $owner/$repo: ${branches.size}") *>
-                      ZIO.foreachDiscard(branches)(branch =>
-                        Console.printLine(s"- ${ExampleSupport.branchSummary(branch)}")
-                      ) *>
-                      Console.printLine(s"Tags for $owner/$repo: ${tags.size}") *>
-                      ZIO.foreachDiscard(tags)(tag =>
-                        Console.printLine(s"- ${ExampleSupport.tagSummary(tag)}")
-                      )
-                )
+    ExampleSupport.runExample("Listing branches and tags", repositoryHint) { client =>
+      repositoryFromEnv match
+        case None => ZIO.succeed(Seq(repositoryHint))
+        case Some((owner, repo)) =>
+          for
+            branches <- client.repos.branches(owner, repo).take(25).runCollect
+            tags <- client.repos.tags(owner, repo).take(25).runCollect
+          yield (s"Branches for $owner/$repo: ${branches.size}" +:
+            branches.map(branch => s"- ${ExampleSupport.branchSummary(branch)}")) ++
+            (s"Tags for $owner/$repo: ${tags.size}" +:
+              tags.map(tag => s"- ${ExampleSupport.tagSummary(tag)}"))
+    }
 
   private def repositoryFromEnv: Option[(String, String)] =
     for
-      owner <- nonBlankEnv(ownerEnv)
-      repo <- nonBlankEnv(repoEnv)
+      owner <- ExampleSupport.optionalEnv(ownerEnv)
+      repo <- ExampleSupport.optionalEnv(repoEnv)
     yield (owner, repo)
-
-  private def nonBlankEnv(name: String): Option[String] =
-    sys.env.get(name).map(_.trim).filter(_.nonEmpty)
 
   private def repositoryHint: String =
     s"Set $ownerEnv and $repoEnv to list repository branches and tags."

--- a/examples/src/io/worxbend/gitea4s/examples/ListBranchesAndTags.scala
+++ b/examples/src/io/worxbend/gitea4s/examples/ListBranchesAndTags.scala
@@ -1,8 +1,8 @@
 package io.worxbend.gitea4s.examples
 
-import zio.{ZIO, ZIOAppDefault}
+import zio.ZIO
 
-object ListBranchesAndTags extends ZIOAppDefault:
+object ListBranchesAndTags extends ExampleApp:
   private val ownerEnv = "GITEA_OWNER"
   private val repoEnv = "GITEA_REPO"
 

--- a/examples/src/io/worxbend/gitea4s/examples/ListMyRepos.scala
+++ b/examples/src/io/worxbend/gitea4s/examples/ListMyRepos.scala
@@ -1,44 +1,21 @@
 package io.worxbend.gitea4s.examples
 
-import io.worxbend.gitea4s.GiteaClient
-import io.worxbend.gitea4s.backend.zio.ZioGiteaBackend
 import io.worxbend.gitea4s.error.GiteaError
 import io.worxbend.gitea4s.http.RepoListParams
-import zio.{Console, ZIO, ZIOAppDefault}
+import zio.{ZIO, ZIOAppDefault}
 
 object ListMyRepos extends ZIOAppDefault:
   def run =
-    ExampleSupport.liveConfigFromEnv match
-      case Right(None) =>
-        Console.printLine(ExampleSupport.referenceLine) *>
-          Console.printLine(ExampleSupport.credentialsHint)
-      case Left(error) =>
-        Console.printLine(ExampleSupport.referenceLine) *>
-          Console.printLineError(s"Cannot read live Gitea config: ${error.message}") *>
-          ZIO.fail(error)
-      case Right(Some(config)) =>
-        val program =
-          ZIO.serviceWithZIO[GiteaClient] { client =>
-            for
-              user <- client.users.me
-              login <- ZIO
-                .fromOption(user.login)
-                .orElseFail(GiteaError.DecodeError("GET /user response did not include login", ""))
-              repositories <- client
-                .repos.list(login, RepoListParams(limit = Some(25)))
-                .take(25)
-                .runCollect
-            yield (login, repositories)
-          }
-
-        Console.printLine(ExampleSupport.referenceLine) *>
-          program
-            .provideLayer(ZioGiteaBackend.configured(config))
-            .foldZIO(
-              error => Console.printLineError(s"Listing repositories failed: ${ExampleSupport.describeFailure(error)}") *> ZIO.fail(error),
-              (login, repositories) =>
-                Console.printLine(s"Repositories for $login: ${repositories.size}") *>
-                  ZIO.foreachDiscard(repositories)(repository =>
-                    Console.printLine(s"- ${ExampleSupport.repositoryName(repository)}")
-                  )
-            )
+    ExampleSupport.runExample("Listing repositories") { client =>
+      for
+        user <- client.users.me
+        login <- ZIO
+          .fromOption(user.login)
+          .orElseFail(GiteaError.DecodeError("GET /user response did not include login", ""))
+        repositories <- client.repos
+          .list(login, RepoListParams(limit = Some(25)))
+          .take(25)
+          .runCollect
+      yield s"Repositories for $login: ${repositories.size}" +:
+        repositories.map(repository => s"- ${ExampleSupport.repositoryName(repository)}")
+    }

--- a/examples/src/io/worxbend/gitea4s/examples/ListMyRepos.scala
+++ b/examples/src/io/worxbend/gitea4s/examples/ListMyRepos.scala
@@ -2,9 +2,9 @@ package io.worxbend.gitea4s.examples
 
 import io.worxbend.gitea4s.error.GiteaError
 import io.worxbend.gitea4s.http.RepoListParams
-import zio.{ZIO, ZIOAppDefault}
+import zio.ZIO
 
-object ListMyRepos extends ZIOAppDefault:
+object ListMyRepos extends ExampleApp:
   def run =
     ExampleSupport.runExample("Listing repositories") { client =>
       for

--- a/examples/src/io/worxbend/gitea4s/examples/ListNotifications.scala
+++ b/examples/src/io/worxbend/gitea4s/examples/ListNotifications.scala
@@ -1,9 +1,9 @@
 package io.worxbend.gitea4s.examples
 
 import io.worxbend.gitea4s.http.{NotificationListParams, NotificationStatusType}
-import zio.{Chunk, ZIOAppDefault}
+import zio.Chunk
 
-object WatchNotifications extends ZIOAppDefault:
+object ListNotifications extends ExampleApp:
   private val params =
     NotificationListParams(
       statusTypes = Chunk(NotificationStatusType.Unread),

--- a/examples/src/io/worxbend/gitea4s/examples/ListPullRequests.scala
+++ b/examples/src/io/worxbend/gitea4s/examples/ListPullRequests.scala
@@ -1,61 +1,38 @@
 package io.worxbend.gitea4s.examples
 
-import io.worxbend.gitea4s.GiteaClient
-import io.worxbend.gitea4s.backend.zio.ZioGiteaBackend
 import io.worxbend.gitea4s.http.{PullRequestListParams, PullRequestListState}
-import zio.{Console, ZIO, ZIOAppDefault}
+import zio.{ZIO, ZIOAppDefault}
 
 object ListPullRequests extends ZIOAppDefault:
   private val ownerEnv = "GITEA_OWNER"
   private val repoEnv = "GITEA_REPO"
 
+  private val params =
+    PullRequestListParams(
+      state = Some(PullRequestListState.All),
+      limit = Some(25)
+    )
+
   def run =
-    ExampleSupport.liveConfigFromEnv match
-      case Right(None) =>
-        Console.printLine(ExampleSupport.referenceLine) *>
-          Console.printLine(ExampleSupport.credentialsHint) *>
-          Console.printLine(repositoryHint)
-      case Left(error) =>
-        Console.printLine(ExampleSupport.referenceLine) *>
-          Console.printLineError(s"Cannot read live Gitea config: ${error.message}") *>
-          ZIO.fail(error)
-      case Right(Some(config)) =>
-        repositoryFromEnv match
-          case None =>
-            Console.printLine(ExampleSupport.referenceLine) *>
-              Console.printLine(repositoryHint)
-          case Some((owner, repo)) =>
-            val params =
-              PullRequestListParams(
-                state = Some(PullRequestListState.All),
-                limit = Some(25)
-              )
-
-            val program =
-              ZIO.serviceWithZIO[GiteaClient] { client =>
-                client.pulls.list(owner, repo, params).take(25).runCollect
-              }
-
-            Console.printLine(ExampleSupport.referenceLine) *>
-              program
-                .provideLayer(ZioGiteaBackend.configured(config))
-                .foldZIO(
-                  error => Console.printLineError(s"Listing pull requests failed: ${ExampleSupport.describeFailure(error)}") *> ZIO.fail(error),
-                  pullRequests =>
-                    Console.printLine(s"Pull requests for $owner/$repo: ${pullRequests.size}") *>
-                      ZIO.foreachDiscard(pullRequests)(pullRequest =>
-                        Console.printLine(s"- ${ExampleSupport.pullRequestSummary(pullRequest)}")
-                      )
-                )
+    ExampleSupport.runExample("Listing pull requests", repositoryHint) { client =>
+      repositoryFromEnv match
+        case None => ZIO.succeed(Seq(repositoryHint))
+        case Some((owner, repo)) =>
+          client.pulls
+            .list(owner, repo, params)
+            .take(25)
+            .runCollect
+            .map { pullRequests =>
+              s"Pull requests for $owner/$repo: ${pullRequests.size}" +:
+                pullRequests.map(pullRequest => s"- ${ExampleSupport.pullRequestSummary(pullRequest)}")
+            }
+    }
 
   private def repositoryFromEnv: Option[(String, String)] =
     for
-      owner <- nonBlankEnv(ownerEnv)
-      repo <- nonBlankEnv(repoEnv)
+      owner <- ExampleSupport.optionalEnv(ownerEnv)
+      repo <- ExampleSupport.optionalEnv(repoEnv)
     yield (owner, repo)
-
-  private def nonBlankEnv(name: String): Option[String] =
-    sys.env.get(name).map(_.trim).filter(_.nonEmpty)
 
   private def repositoryHint: String =
     s"Set $ownerEnv and $repoEnv to list repository pull requests."

--- a/examples/src/io/worxbend/gitea4s/examples/ListPullRequests.scala
+++ b/examples/src/io/worxbend/gitea4s/examples/ListPullRequests.scala
@@ -1,9 +1,9 @@
 package io.worxbend.gitea4s.examples
 
 import io.worxbend.gitea4s.http.{PullRequestListParams, PullRequestListState}
-import zio.{ZIO, ZIOAppDefault}
+import zio.ZIO
 
-object ListPullRequests extends ZIOAppDefault:
+object ListPullRequests extends ExampleApp:
   private val ownerEnv = "GITEA_OWNER"
   private val repoEnv = "GITEA_REPO"
 

--- a/examples/src/io/worxbend/gitea4s/examples/ListReleases.scala
+++ b/examples/src/io/worxbend/gitea4s/examples/ListReleases.scala
@@ -1,8 +1,8 @@
 package io.worxbend.gitea4s.examples
 
-import zio.{ZIO, ZIOAppDefault}
+import zio.ZIO
 
-object ListReleases extends ZIOAppDefault:
+object ListReleases extends ExampleApp:
   private val ownerEnv = "GITEA_OWNER"
   private val repoEnv = "GITEA_REPO"
 

--- a/examples/src/io/worxbend/gitea4s/examples/ListReleases.scala
+++ b/examples/src/io/worxbend/gitea4s/examples/ListReleases.scala
@@ -1,54 +1,31 @@
 package io.worxbend.gitea4s.examples
 
-import io.worxbend.gitea4s.GiteaClient
-import io.worxbend.gitea4s.backend.zio.ZioGiteaBackend
-import zio.{Console, ZIO, ZIOAppDefault}
+import zio.{ZIO, ZIOAppDefault}
 
 object ListReleases extends ZIOAppDefault:
   private val ownerEnv = "GITEA_OWNER"
   private val repoEnv = "GITEA_REPO"
 
   def run =
-    ExampleSupport.liveConfigFromEnv match
-      case Right(None) =>
-        Console.printLine(ExampleSupport.referenceLine) *>
-          Console.printLine(ExampleSupport.credentialsHint) *>
-          Console.printLine(repositoryHint)
-      case Left(error) =>
-        Console.printLine(ExampleSupport.referenceLine) *>
-          Console.printLineError(s"Cannot read live Gitea config: ${error.message}") *>
-          ZIO.fail(error)
-      case Right(Some(config)) =>
-        repositoryFromEnv match
-          case None =>
-            Console.printLine(ExampleSupport.referenceLine) *>
-              Console.printLine(repositoryHint)
-          case Some((owner, repo)) =>
-            val program =
-              ZIO.serviceWithZIO[GiteaClient] { client =>
-                client.releases.list(owner, repo).take(25).runCollect
-              }
-
-            Console.printLine(ExampleSupport.referenceLine) *>
-              program
-                .provideLayer(ZioGiteaBackend.configured(config))
-                .foldZIO(
-                  error => Console.printLineError(s"Listing releases failed: ${ExampleSupport.describeFailure(error)}") *> ZIO.fail(error),
-                  releases =>
-                    Console.printLine(s"Releases for $owner/$repo: ${releases.size}") *>
-                      ZIO.foreachDiscard(releases)(release =>
-                        Console.printLine(s"- ${ExampleSupport.releaseSummary(release)}")
-                      )
-                )
+    ExampleSupport.runExample("Listing releases", repositoryHint) { client =>
+      repositoryFromEnv match
+        case None => ZIO.succeed(Seq(repositoryHint))
+        case Some((owner, repo)) =>
+          client.releases
+            .list(owner, repo)
+            .take(25)
+            .runCollect
+            .map { releases =>
+              s"Releases for $owner/$repo: ${releases.size}" +:
+                releases.map(release => s"- ${ExampleSupport.releaseSummary(release)}")
+            }
+    }
 
   private def repositoryFromEnv: Option[(String, String)] =
     for
-      owner <- nonBlankEnv(ownerEnv)
-      repo <- nonBlankEnv(repoEnv)
+      owner <- ExampleSupport.optionalEnv(ownerEnv)
+      repo <- ExampleSupport.optionalEnv(repoEnv)
     yield (owner, repo)
-
-  private def nonBlankEnv(name: String): Option[String] =
-    sys.env.get(name).map(_.trim).filter(_.nonEmpty)
 
   private def repositoryHint: String =
     s"Set $ownerEnv and $repoEnv to list repository releases."

--- a/examples/src/io/worxbend/gitea4s/examples/OrgMembers.scala
+++ b/examples/src/io/worxbend/gitea4s/examples/OrgMembers.scala
@@ -1,41 +1,24 @@
 package io.worxbend.gitea4s.examples
 
-import io.worxbend.gitea4s.GiteaClient
-import io.worxbend.gitea4s.backend.zio.ZioGiteaBackend
-import zio.{Console, ZIO, ZIOAppDefault}
+import zio.{ZIO, ZIOAppDefault}
 
 object OrgMembers extends ZIOAppDefault:
   private val orgEnv = "GITEA_ORG"
 
   def run =
-    ExampleSupport.liveConfigFromEnv match
-      case Right(None) =>
-        Console.printLine(ExampleSupport.referenceLine) *>
-          Console.printLine(ExampleSupport.credentialsHint) *>
-          Console.printLine(s"Set $orgEnv to list organization members.")
-      case Left(error) =>
-        Console.printLine(ExampleSupport.referenceLine) *>
-          Console.printLineError(s"Cannot read live Gitea config: ${error.message}") *>
-          ZIO.fail(error)
-      case Right(Some(config)) =>
-        sys.env.get(orgEnv).map(_.trim).filter(_.nonEmpty) match
-          case None =>
-            Console.printLine(ExampleSupport.referenceLine) *>
-              Console.printLine(s"Set $orgEnv to list organization members.")
-          case Some(org) =>
-            val program =
-              ZIO.serviceWithZIO[GiteaClient] { client =>
-                client.orgs.members(org).take(25).runCollect
-              }
+    ExampleSupport.runExample("Listing organization members", orgHint) { client =>
+      ExampleSupport.optionalEnv(orgEnv) match
+        case None => ZIO.succeed(Seq(orgHint))
+        case Some(org) =>
+          client.orgs
+            .members(org)
+            .take(25)
+            .runCollect
+            .map { members =>
+              s"Members of $org: ${members.size}" +:
+                members.map(member => s"- ${ExampleSupport.userName(member)}")
+            }
+    }
 
-            Console.printLine(ExampleSupport.referenceLine) *>
-              program
-                .provideLayer(ZioGiteaBackend.configured(config))
-                .foldZIO(
-                  error => Console.printLineError(s"Listing organization members failed: ${ExampleSupport.describeFailure(error)}") *> ZIO.fail(error),
-                  members =>
-                    Console.printLine(s"Members of $org: ${members.size}") *>
-                      ZIO.foreachDiscard(members)(member =>
-                        Console.printLine(s"- ${ExampleSupport.userName(member)}")
-                      )
-                )
+  private def orgHint: String =
+    s"Set $orgEnv to list organization members."

--- a/examples/src/io/worxbend/gitea4s/examples/OrgMembers.scala
+++ b/examples/src/io/worxbend/gitea4s/examples/OrgMembers.scala
@@ -1,8 +1,8 @@
 package io.worxbend.gitea4s.examples
 
-import zio.{ZIO, ZIOAppDefault}
+import zio.ZIO
 
-object OrgMembers extends ZIOAppDefault:
+object OrgMembers extends ExampleApp:
   private val orgEnv = "GITEA_ORG"
 
   def run =

--- a/examples/src/io/worxbend/gitea4s/examples/SearchUsers.scala
+++ b/examples/src/io/worxbend/gitea4s/examples/SearchUsers.scala
@@ -1,46 +1,25 @@
 package io.worxbend.gitea4s.examples
 
-import io.worxbend.gitea4s.GiteaClient
-import io.worxbend.gitea4s.backend.zio.ZioGiteaBackend
 import io.worxbend.gitea4s.http.UserSearchParams
-import zio.{Console, ZIO, ZIOAppDefault}
+import zio.{ZIO, ZIOAppDefault}
 
 object SearchUsers extends ZIOAppDefault:
   private val queryEnv = "GITEA_USER_QUERY"
 
   def run =
-    ExampleSupport.liveConfigFromEnv match
-      case Right(None) =>
-        Console.printLine(ExampleSupport.referenceLine) *>
-          Console.printLine(ExampleSupport.credentialsHint) *>
-          Console.printLine(queryHint)
-      case Left(error) =>
-        Console.printLine(ExampleSupport.referenceLine) *>
-          Console.printLineError(s"Cannot read live Gitea config: ${error.message}") *>
-          ZIO.fail(error)
-      case Right(Some(config)) =>
-        sys.env.get(queryEnv).map(_.trim).filter(_.nonEmpty) match
-          case None =>
-            Console.printLine(ExampleSupport.referenceLine) *>
-              Console.printLine(queryHint)
-          case Some(query) =>
-            val params = UserSearchParams(q = Some(query), limit = Some(25))
-            val program =
-              ZIO.serviceWithZIO[GiteaClient] { client =>
-                client.users.search(params).take(25).runCollect
-              }
-
-            Console.printLine(ExampleSupport.referenceLine) *>
-              program
-                .provideLayer(ZioGiteaBackend.configured(config))
-                .foldZIO(
-                  error => Console.printLineError(s"Searching users failed: ${ExampleSupport.describeFailure(error)}") *> ZIO.fail(error),
-                  users =>
-                    Console.printLine(s"Users matching '$query': ${users.size}") *>
-                      ZIO.foreachDiscard(users)(user =>
-                        Console.printLine(s"- ${ExampleSupport.userName(user)}")
-                      )
-                )
+    ExampleSupport.runExample("Searching users", queryHint) { client =>
+      ExampleSupport.optionalEnv(queryEnv) match
+        case None => ZIO.succeed(Seq(queryHint))
+        case Some(query) =>
+          client.users
+            .search(UserSearchParams(q = Some(query), limit = Some(25)))
+            .take(25)
+            .runCollect
+            .map { users =>
+              s"Users matching '$query': ${users.size}" +:
+                users.map(user => s"- ${ExampleSupport.userName(user)}")
+            }
+    }
 
   private def queryHint: String =
     s"Set $queryEnv to search users."

--- a/examples/src/io/worxbend/gitea4s/examples/SearchUsers.scala
+++ b/examples/src/io/worxbend/gitea4s/examples/SearchUsers.scala
@@ -1,9 +1,9 @@
 package io.worxbend.gitea4s.examples
 
 import io.worxbend.gitea4s.http.UserSearchParams
-import zio.{ZIO, ZIOAppDefault}
+import zio.ZIO
 
-object SearchUsers extends ZIOAppDefault:
+object SearchUsers extends ExampleApp:
   private val queryEnv = "GITEA_USER_QUERY"
 
   def run =

--- a/examples/src/io/worxbend/gitea4s/examples/ShowApiReference.scala
+++ b/examples/src/io/worxbend/gitea4s/examples/ShowApiReference.scala
@@ -1,9 +1,7 @@
 package io.worxbend.gitea4s.examples
 
-import zio.ZIOAppDefault
-
-object ShowApiReference extends ZIOAppDefault:
+object ShowApiReference extends ExampleApp:
   def run =
-    ExampleSupport.runExample("GET /user") { client =>
-      client.users.me.map(user => Seq(s"Authenticated as ${user.login.getOrElse("<unknown>")}"))
+    ExampleSupport.runExample("Reading the current user") { client =>
+      client.users.me.map(user => Seq(s"Authenticated as ${ExampleSupport.userName(user)}"))
     }

--- a/examples/src/io/worxbend/gitea4s/examples/ShowApiReference.scala
+++ b/examples/src/io/worxbend/gitea4s/examples/ShowApiReference.scala
@@ -1,23 +1,9 @@
 package io.worxbend.gitea4s.examples
 
-import io.worxbend.gitea4s.backend.zio.ZioGiteaBackend
-import zio.{Console, ZIO, ZIOAppDefault}
+import zio.ZIOAppDefault
 
 object ShowApiReference extends ZIOAppDefault:
   def run =
-    ExampleSupport.liveConfigFromEnv match
-      case Right(None) =>
-        Console.printLine(ExampleSupport.referenceLine) *>
-          Console.printLine(ExampleSupport.credentialsHint)
-      case Left(error) =>
-        Console.printLine(ExampleSupport.referenceLine) *>
-          Console.printLineError(s"Cannot read live Gitea config: ${error.message}") *>
-          ZIO.fail(error)
-      case Right(Some(config)) =>
-        Console.printLine(ExampleSupport.referenceLine) *>
-          ZIO.serviceWithZIO[io.worxbend.gitea4s.GiteaClient](_.users.me)
-            .provideLayer(ZioGiteaBackend.configured(config))
-            .foldZIO(
-              error => Console.printLineError(s"GET /user failed: ${ExampleSupport.describeFailure(error)}") *> ZIO.fail(error),
-              user => Console.printLine(s"Authenticated as ${user.login.getOrElse("<unknown>")}")
-            )
+    ExampleSupport.runExample("GET /user") { client =>
+      client.users.me.map(user => Seq(s"Authenticated as ${user.login.getOrElse("<unknown>")}"))
+    }

--- a/examples/src/io/worxbend/gitea4s/examples/WatchNotifications.scala
+++ b/examples/src/io/worxbend/gitea4s/examples/WatchNotifications.scala
@@ -1,43 +1,20 @@
 package io.worxbend.gitea4s.examples
 
-import io.worxbend.gitea4s.GiteaClient
-import io.worxbend.gitea4s.backend.zio.ZioGiteaBackend
 import io.worxbend.gitea4s.http.{NotificationListParams, NotificationStatusType}
-import zio.{Chunk, Console, ZIO, ZIOAppDefault}
+import zio.{Chunk, ZIOAppDefault}
 
 object WatchNotifications extends ZIOAppDefault:
+  private val params =
+    NotificationListParams(
+      statusTypes = Chunk(NotificationStatusType.Unread),
+      limit = Some(20)
+    )
+
   def run =
-    ExampleSupport.liveConfigFromEnv match
-      case Right(None) =>
-        Console.printLine(ExampleSupport.referenceLine) *>
-          Console.printLine(ExampleSupport.credentialsHint)
-      case Left(error) =>
-        Console.printLine(ExampleSupport.referenceLine) *>
-          Console.printLineError(s"Cannot read live Gitea config: ${error.message}") *>
-          ZIO.fail(error)
-      case Right(Some(config)) =>
-        val params =
-          NotificationListParams(
-            statusTypes = Chunk(NotificationStatusType.Unread),
-            limit = Some(20)
-          )
-
-        val program =
-          ZIO.serviceWithZIO[GiteaClient] { client =>
-            for
-              count <- client.notifications.unreadCount
-              threads <- client.notifications.list(params).take(20).runCollect
-            yield (count, threads)
-          }
-
-        Console.printLine(ExampleSupport.referenceLine) *>
-          program
-            .provideLayer(ZioGiteaBackend.configured(config))
-            .foldZIO(
-              error => Console.printLineError(s"Reading notifications failed: ${ExampleSupport.describeFailure(error)}") *> ZIO.fail(error),
-              (count, threads) =>
-                Console.printLine(s"Unread notifications: ${count.unread.getOrElse(0L)}") *>
-                  ZIO.foreachDiscard(threads)(thread =>
-                    Console.printLine(s"- ${ExampleSupport.notificationSummary(thread)}")
-                  )
-            )
+    ExampleSupport.runExample("Reading notifications") { client =>
+      for
+        count <- client.notifications.unreadCount
+        threads <- client.notifications.list(params).take(20).runCollect
+      yield s"Unread notifications: ${count.unread.getOrElse(0L)}" +:
+        threads.map(thread => s"- ${ExampleSupport.notificationSummary(thread)}")
+    }

--- a/it/test/src/io/worxbend/gitea4s/it/LiveGiteaIntegrationSpec.scala
+++ b/it/test/src/io/worxbend/gitea4s/it/LiveGiteaIntegrationSpec.scala
@@ -160,8 +160,14 @@ object LiveGiteaIntegrationSpec extends ZIOSpecDefault:
         TestAspect.ifEnv(Env.repo)(nonEmptyValue) @@
         TestAspect.ifEnv(Env.releaseId)(nonEmptyValue) @@
         TestAspect.ifEnv(Env.releaseAssetId)(nonEmptyValue)
-    ) @@ TestAspect.ifEnv(GiteaConfig.Env.url)((value: String) => value.trim.nonEmpty) @@
-      TestAspect.ifEnv(GiteaConfig.Env.token)((value: String) => value.trim.nonEmpty)
+    ) @@ TestAspect.ifEnv(Env.optIn)(nonEmptyValue) @@
+      TestAspect.ifEnv(GiteaConfig.Env.url)(nonEmptyValue) @@
+      // Not `ifEnv(GITEA_TOKEN)`: that aspect reads one variable, and basic
+      // auth is an equal credential path here and in `GiteaConfig.fromEnv`.
+      // Gating on the token alone meant a username/password configuration
+      // reported twelve ignored tests and a green SUCCESS having made no
+      // network calls at all — the configuration was never actually exercised.
+      ifLiveCredentials
 
   private def withLiveClient(
       run: GiteaClient => ZIO[Any, Any, TestResult]
@@ -173,15 +179,31 @@ object LiveGiteaIntegrationSpec extends ZIOSpecDefault:
       // way — were those aspects ever dropped, a green "passed" that ran no
       // live call is the one outcome this suite must never produce.
       case Right(None) =>
-        ZIO.fail(s"${GiteaConfig.Env.url} and ${GiteaConfig.Env.token} must be set to run a live test")
+        ZIO.fail(
+          s"${Env.optIn}, ${GiteaConfig.Env.url} and credentials must be set to run a live test"
+        )
       case Left(error) => ZIO.fail(error.message)
       case Right(Some(config)) =>
         ZIO.serviceWithZIO[GiteaClient](run).provideLayer(ZioGiteaBackend.configured(config))
 
   private def liveConfig: Either[GiteaConfigError, Option[GiteaConfig]] =
     val env = sys.env.toMap
-    if nonBlank(env, GiteaConfig.Env.url).isEmpty || nonBlank(env, GiteaConfig.Env.token).isEmpty then Right(None)
+    if nonBlank(env, Env.optIn).isEmpty || nonBlank(env, GiteaConfig.Env.url).isEmpty then Right(None)
+    else if !credentialsConfigured(env) then Right(None)
     else GiteaConfig.fromEnv(env).map(Some(_))
+
+  /** Runs the suite only when some credential path is configured.
+    *
+    * Written by hand rather than with `TestAspect.ifEnv`, which reads a single
+    * variable and so cannot express "a token, or a username *and* a password".
+    */
+  private val ifLiveCredentials: TestAspectPoly =
+    if credentialsConfigured(sys.env.toMap) then TestAspect.identity else TestAspect.ignore
+
+  /** Either credential path `GiteaConfig.fromEnv` accepts. */
+  private def credentialsConfigured(env: Map[String, String]): Boolean =
+    nonBlank(env, GiteaConfig.Env.token).nonEmpty ||
+      (nonBlank(env, GiteaConfig.Env.username).nonEmpty && nonBlank(env, GiteaConfig.Env.password).nonEmpty)
 
   private def liveEnv(name: String): ZIO[Any, String, String] =
     ZIO.fromOption(nonBlank(sys.env.toMap, name)).orElseFail(s"$name must be configured for this live test")
@@ -212,6 +234,17 @@ object LiveGiteaIntegrationSpec extends ZIOSpecDefault:
     value.trim.nonEmpty
 
   private object Env:
+    /** Explicit opt-in for the whole suite.
+      *
+      * `it.test` is part of the `__.test` aggregate that CONTRIBUTING calls
+      * "hermetic unit tests". Gating only on credentials meant that on any
+      * machine with GITEA_URL and GITEA_TOKEN exported — a maintainer's, in
+      * other words — the documented pre-PR command made authenticated calls
+      * against a real server. Requiring a variable nobody exports by accident
+      * makes the hermetic claim true.
+      */
+    val optIn = "GITEA_IT"
+
     val owner = "GITEA_OWNER"
     val repo = "GITEA_REPO"
     val ref = "GITEA_REF"

--- a/it/test/src/io/worxbend/gitea4s/it/LiveGiteaIntegrationSpec.scala
+++ b/it/test/src/io/worxbend/gitea4s/it/LiveGiteaIntegrationSpec.scala
@@ -167,7 +167,13 @@ object LiveGiteaIntegrationSpec extends ZIOSpecDefault:
       run: GiteaClient => ZIO[Any, Any, TestResult]
   ): ZIO[Any, Any, TestResult] =
     liveConfig match
-      case Right(None) => ZIO.succeed(assertTrue(true))
+      // Unreachable today: the suite carries `ifEnv` aspects on GITEA_URL and
+      // GITEA_TOKEN, so an unconfigured run reports every test as *ignored*
+      // rather than reaching this. Failing rather than succeeding keeps it that
+      // way — were those aspects ever dropped, a green "passed" that ran no
+      // live call is the one outcome this suite must never produce.
+      case Right(None) =>
+        ZIO.fail(s"${GiteaConfig.Env.url} and ${GiteaConfig.Env.token} must be set to run a live test")
       case Left(error) => ZIO.fail(error.message)
       case Right(Some(config)) =>
         ZIO.serviceWithZIO[GiteaClient](run).provideLayer(ZioGiteaBackend.configured(config))

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,17 +1,25 @@
 # JitPack build configuration — https://jitpack.io/#worxbend/gitea-scala-client
 #
 # JitPack builds gitea4s on demand from a git tag or commit. The default JitPack
-# image ships Java 8, and the `jdk:` key does not offer Java 21, so we install
-# Temurin 21 through SDKMAN (the build targets `--release 21`) before publishing
+# image ships Java 8 and its `jdk:` key does not offer Java 21, so Temurin 21 is
+# installed through SDKMAN (the build targets `--release 21`) before publishing
 # every publishable module into the local Maven repository JitPack serves from.
 #
 # `./mill __.publishM2Local` writes to ~/.m2/repository by default, which is
 # exactly where JitPack looks for build output.
-jdk:
-  - openjdk21
 before_install:
   # Bump this Temurin build if SDKMAN ever delists this exact patch release.
   - sdk install java 21.0.5-tem
   - sdk use java 21.0.5-tem
 install:
+  # Compile and test before publishing. JitPack serves whatever these coordinates
+  # resolve to, so an unvalidated build here is a broken artifact somebody
+  # downloads — and JitPack's job is to serve pre-release commits, which are
+  # exactly the ones most likely to be broken.
+  #
+  # `compatibility.check` is deliberately absent: it would fail every commit
+  # whose api-snapshot baseline has not been regenerated yet, which is precisely
+  # the pre-release traffic this channel exists for.
+  - ./mill __.compile
+  - ./mill __.test
   - ./mill __.publishM2Local


### PR DESCRIPTION
## What this does

A second review pass over gitea4s, covering everything the first one left out:
the 66 findings it deferred unverified, plus five areas no reviewer had looked
at — `examples/`, `it/`, `build.mill`, the GitHub workflows, and the prose docs.

Eighteen commits, one logical change each. The headline items are three bugs
that would bite a real user, two release-safety holes, and the removal of a
large amount of code and test that looked like protection and was not.

> **Stacked on #6.** This branch starts from `refactor/multi-lens-cleanup`.
> Review or merge that one first; the diff below is only the new commits.

## Why

The first pass verified its top 24 findings and deferred 66 for budget reasons —
not because anyone judged them wrong. This pass triaged all 66 (31 survived, 35
refuted) and reviewed the unscoped areas fresh.

### The bugs

**A newer Gitea could silently empty your collections.** Every enum decoder
rejected any string it did not already list, and `decodePage` decodes a page as
one `Chunk`, so a single unrecognised value failed the *entire page* — and the
`ZStream` above it, losing every later page too. Demonstrated before the fix,
with two notifications where only the second is unfamiliar:

```
Left([1].subject.state(Unknown notification subject state: draft))
```

The valid first notification is gone with it. Gitea adds enum members between
minor versions (`fast-forward-only` is recent), so this fires on a server
upgrade, not in theory. Read positions now decode an unknown value as `None`;
write positions stay strict, because sending a value the server will reject is
worth failing on.

**`timeout = 30` in HOCON meant 30 milliseconds.** Typesafe Config reads a
unitless number in duration position as milliseconds. Measured:

```
hocon(timeout = 30)   -> Right(30000000 nanoseconds)
env(GITEA_TIMEOUT=30) -> Left(GITEA_TIMEOUT must be a positive finite duration such as 30s)
```

The same text, two very different meanings, and the wrong one silent: every call
then failed as a transport timeout, three retries deep, with nothing pointing at
the config file. Separately, `maxRetries` written in a `gitea4s { }` block is a
different key from `max-retries` and was read by nobody — the config loaded and
the setting did nothing.

**A hanging observer withheld a finished result.** `catchAllCause` covers an
observer that *fails*, not one that never returns — and the escape hatch the
scaladoc recommends, offering to a `Queue`, is exactly what suspends when that
queue is full. Reverting the fix makes the new test hang past 300 seconds.

### The release holes

**Publishing never checked the version it was shipping.** `release.yml`
validated the *shape* of a `v*` tag only, so tagging `v2.0.0` while `build.mill`
still said `1.0.0` published 1.0.0 jars, attached them to a Release called
v2.0.0, and reported success — leaving `2.0.0` unresolvable and `1.0.0` quietly
overwritten. `publish-central.yml` is worse if it goes wrong, because Central is
immutable: dispatched by hand against any ref, its only gate was a SNAPSHOT
check.

**Secrets travelled in argv.** The Central publish passed `--password` and a
`--gpgArgs` string containing `--passphrase=` — both readable through
`/proc/<pid>/cmdline` and `ps` — while all four credentials were already in
`env:` where Mill reads them by default.

### Things that looked like protection

- **`./mill __.test` was not hermetic.** `it.test` is in that aggregate, which
  CONTRIBUTING calls "hermetic unit tests", and the live suite gated only on
  `GITEA_URL`/`GITEA_TOKEN`. On a maintainer's machine the documented pre-PR
  command made authenticated calls against a real server.
- **Basic-auth live runs were skipped entirely** — the gate hardcoded
  `GITEA_TOKEN`, so a username/password configuration reported twelve ignored
  tests and a green `SUCCESS` having made no network call.
- **300 assertions could not fail.** Blocks that pin `endpoint ==
  GiteaEndpoints.orgGet` went on to assert that endpoint's `operationId`,
  `path`, `parameters` and `response`. Case-class equality had already decided
  all of them.
- **Backoff growth was unexercised**, so replacing the doubling with a constant
  left the build green. **"Gives up once the budget is spent"** asserted only
  `isLeft`, which passes with zero retries. **The API version** was checked
  against a retyped copy of itself. Three live assertions (`repos.length <= 1`
  after `.take(1)`, `contents != null`, a doubly-vacuous `forall`) were
  unconditionally true.
- **JitPack published without building anything** — `install:` ran only
  `publishM2Local`, on the channel whose whole purpose is serving pre-release
  commits.
- **The CI cache never matched.** All three workflows cached `~/.mill`; the
  launcher downloads into `${XDG_CACHE_HOME:-$HOME/.cache}/mill`, so ~119 MB was
  re-fetched every job.

### Docs that were wrong

README and CHANGELOG both promised that a retry instant "more than 24 hours out
is ignored entirely". No such rule exists — and `GiteaResponseMapper.retryAt`
says the opposite in its own comment. A reader who believed it would have
trusted `RateLimited.resetAt` without validating it.

## How it works

Beyond the fixes above:

- **`GiteaError.message`** on the sealed trait — nine cases already had one,
  four now derive one, so logging an error no longer needs a thirteen-case
  match. Derived methods, never constructor parameters.
- **`GITEA_USER_AGENT` / `GITEA_OTP`**, through the same control-character guard
  as the credentials, so the two config sources finally accept the same
  settings. The OTP one is documented as near-useless for a long-running process
  — `X-Gitea-OTP` is time-based.
- **`paginatedWindow`** resolves `page`/`pageSize` once instead of at 14 sites,
  where the same two numbers had to reach both the query and the `Page` built
  from the reply. A stale one produced a `Page` misreporting its own page number
  with no compile error.
- **`Accept` is a closed enum.** It was a `String` matched against three loose
  constants with a silent fall-through, and the call sites had drifted into four
  spellings including two bare `"application/octet-stream"` literals.
- **`BinaryTarget`** names each binary endpoint once. A comment claimed the
  buffered and streaming builders mirrored each other; nothing enforced it, and
  the spec asserted only the streaming URI. A test now checks the property.
- **`com.typesafe:config` is declared directly.** The build depended on
  `zio-config`, which is imported nowhere, while `com.typesafe.config.Config`
  appears in a *public signature* as a transitive-only dependency.
- **The examples** report each failure once instead of twice (`GiteaError` is
  not a `Throwable`, so ZIO's default handler dumped every failure again as a
  `cause=` wall), and their 13-case error mirror is gone now that
  `GiteaError.message` exists.

## How to test it

```bash
./mill clean
./mill __.compile __.test examples.run compatibility.check
```

Green from clean. `compatibility.check` is the one to read: all four snapshots
change, every entry an addition, plus one removal — a `private final class` no
Scala caller could name.

Each new guard was checked to fail without its fix:

```bash
# Enum drift: delete one `given JsonDecoder[Option[IssueState]]`
#   -> "each read-position enum tolerates an unknown value" fails
# Backoff: make the delay constant
#   -> "backs off further after each failed attempt" fails on attempts == 3
# Observer bound: remove the timeout
#   -> the suite does not finish within 300s
# Binary pair: point rawFileDownload at the media target
#   -> "each streaming download targets exactly what its buffered twin does" fails
# Schema reader: drop `uuid` from the Attachment checklist
#   -> "Attachment checklist missing uuid"
```

Release gates, checked locally: the version extraction returns `1.0.0`; `v1.0.0`
is accepted while `v2.0.0` and `v1.0.0-rc1` are refused; `git tag --points-at
HEAD` correctly refuses an untagged commit.

Integration gating, both directions: with credentials but no `GITEA_IT` every
test reports *ignored*; with `GITEA_IT=1` the baseline test actually attempts
the call.

## Notes for reviewers

**One change I cannot exercise here.** Removing `--username` / `--password` /
`--gpgArgs` from the Central publish only runs during a real release. It fails
closed — if Mill did not pick the environment variables up, the publish errors
rather than shipping something wrong — but the next release is its first real
test. Worth a dry run.

**A process finding worth keeping.** `./mill compatibility.check` reported
SUCCESS on stale build state and hid a snapshot removal for one commit. A clean
run caught it. Run it after `./mill clean` before trusting it to gate a release.

**Two things I was wrong about mid-review**, both corrected before landing:
I claimed the live integration tests "pass vacuously" — they don't,
`TestAspect.ifEnv` already reports them ignored, and I verified by running them.
And I wrote a comment asserting sttp's `.delete` cannot take a body; it can, so
the code uses `.delete` and the comment is gone.

**Judgement calls I made against the review's advice**, each deliberate:

- **Kept the `Page` codec memoisation.** The review recommended deleting it as
  dead weight since nothing in the library serialises a `Page`. But the `given`
  is public, so a *user* can, and the cache is bounded, tested and correct.
  Deleting a working optimisation on the published surface is churn with a small
  downside and no upside beyond line count.
- **Left the 20 duplicated retry tests in `GiteaClientSpec`.** They do re-prove
  one policy once per endpoint, but they exercise the whole client stack rather
  than restating a literal, so thinning them is a coverage judgement rather than
  a provable redundancy — better made in review than folded into a PR this size.

**Known trade-off, unchanged from #6:** `CoreModelsSpec` and `ApiReferenceSpec`
scrape the vendored YAML by indentation, so reformatting `plugin-redoc-2.yaml`
breaks them. They fail loudly and locally, which beats a check that silently
compares two hand-maintained copies.

**Deliberately out of scope:** a `dns`/`tls`/`connect` transport-error taxonomy
(needs per-backend exception sniffing, brittle forever); an error-cause tag on
`GiteaObserver.metrics` (changes the cardinality of series operators already
graph); download-stream observer events (needs a decision about what `duration`
even means when the body outlives the send); and pinning GitHub Actions to
commit SHAs, which wants a Renovate digest-pinning run rather than hand-resolved
hashes.
